### PR TITLE
Add Rename component

### DIFF
--- a/addons/ammunition/CfgMagazines.hpp
+++ b/addons/ammunition/CfgMagazines.hpp
@@ -1,33 +1,9 @@
 class CfgMagazines {
     class CA_Magazine;
+    class 30Rnd_556x45_Stanag_green;
     class ACE_30Rnd_556x45_Stanag_M995_AP_mag;
     class ACE_30Rnd_556x45_Stanag_Mk262_mag;
     class ACE_30Rnd_556x45_Stanag_Mk318_mag;
-
-    // Renaming for matching name conventions.
-    class 30Rnd_556x45_Stanag: CA_Magazine {
-        displayName = "$STR_Ammunition_30Rnd_556x45_Stanag_Display";
-    };
-
-    class 30Rnd_556x45_Stanag_green: 30Rnd_556x45_Stanag {
-        displayName = "$STR_Ammunition_30Rnd_556x45_Stanag_green_Display";
-    };
-
-    class 30Rnd_556x45_Stanag_red: 30Rnd_556x45_Stanag {
-        displayName = "$STR_Ammunition_30Rnd_556x45_Stanag_red_Display";
-    };
-
-    class 30Rnd_556x45_Stanag_Tracer_Green: 30Rnd_556x45_Stanag {
-        displayName = "$STR_Ammunition_30Rnd_556x45_Stanag_Tracer_Green_Display";
-    };
-
-    class 30Rnd_556x45_Stanag_Tracer_Red: 30Rnd_556x45_Stanag {
-        displayName = "$STR_Ammunition_30Rnd_556x45_Stanag_Tracer_Red_Display";
-    };
-
-    class 30Rnd_556x45_Stanag_Tracer_Yellow: 30Rnd_556x45_Stanag {
-        displayName = "$STR_Ammunition_30Rnd_556x45_Stanag_Tracer_Yellow_Display";
-    };
 
     CLASS(8Rnd_P_000): CA_Magazine {
         author = "TyroneMF";

--- a/addons/ammunition/stringtable.xml
+++ b/addons/ammunition/stringtable.xml
@@ -57,23 +57,5 @@
         <Key ID="STR_Ammunition_TACGT_30Rnd_556X45_MK318_EMAG_Display">
             <English>5.56mm 30Rnd EMAG (MK318)</English>
         </Key>
-        <Key ID="STR_Ammunition_30Rnd_556x45_Stanag_Display">
-            <English>5.56mm 30Rnd STANAG RT Yellow</English>
-        </Key>
-        <Key ID="STR_Ammunition_30Rnd_556x45_Stanag_green_Display">
-            <English>5.56mm 30Rnd STANAG RT Green</English>
-        </Key>
-        <Key ID="STR_Ammunition_30Rnd_556x45_Stanag_red_Display">
-            <English>5.56mm 30Rnd STANAG RT Red</English>
-        </Key>
-        <Key ID="STR_Ammunition_30Rnd_556x45_Stanag_Tracer_Green_Display">
-            <English>5.56mm 30Rnd STANAG Tracer Green</English>
-        </Key>
-        <Key ID="STR_Ammunition_30Rnd_556x45_Stanag_Tracer_Red_Display">
-            <English>5.56mm 30Rnd STANAG Tracer Red</English>
-        </Key>
-        <Key ID="STR_Ammunition_30Rnd_556x45_Stanag_Tracer_Yellow_Display">
-            <English>5.56mm 30Rnd STANAG Tracer Yellow</English>
-        </Key>
     </Package>
 </Project>

--- a/addons/glock/CfgWeapons.hpp
+++ b/addons/glock/CfgWeapons.hpp
@@ -1,19 +1,19 @@
 class CfgWeapons {
     class Pistol_Base_F;
     class CUP_hgun_Glock17: Pistol_Base_F {
-        displayName = "$STR_Hgun_Glock17_Display";
+        displayName = "$STR_TACGT_Glock_Glock17_Display";
     };
     class CUP_hgun_Glock17_tan: CUP_hgun_Glock17 {
-        displayName = "$STR_Hgun_Glock17_Tan_Display";
+        displayName = "$STR_TACGT_Glock_Glock17_Tan_Display";
     };
     class CUP_hgun_Glock17_blk: CUP_hgun_Glock17 {
-        displayName = "$STR_Hgun_Glock17_Black_Display";
+        displayName = "$STR_TACGT_Glock_Glock17_Black_Display";
     };
 
     CLASS(hgun_Glock18_Tan): CUP_hgun_Glock17_tan {
         author = "CUP, TyroneMF";
         scope = 2;
-        displayName = "$STR_TACGT_Hgun_Glock18_Tan_Display";
+        displayName = "$STR_TACGT_Glock_Glock18_Tan_Display";
 
         autoFire = 1;
         modes[] = {"Single", "FullAuto"};
@@ -57,7 +57,7 @@ class CfgWeapons {
 
     CLASS(hgun_Glock18_Black): tacgt_hgun_Glock18_Tan {
         scope = 2;
-        displayName = "$STR_TACGT_Hgun_Glock18_Black_Display";
+        displayName = "$STR_TACGT_Glock_Glock18_Black_Display";
         hiddenSelections[] = {"Camo"};
         hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_glock17\data\glock17_blk_co.paa"};
     };

--- a/addons/glock/stringtable.xml
+++ b/addons/glock/stringtable.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project name="TACGT">
     <Package name="Glock">
-        <Key ID="STR_Hgun_Glock17_Display">
+        <Key ID="STR_TACGT_Glock_Glock17_Display">
             <English>Glock 17</English>
             <French>Glock 17</French>
         </Key>
-        <Key ID="STR_Hgun_Glock17_Tan_Display">
+        <Key ID="STR_TACGT_Glock_Glock17_Tan_Display">
             <English>Glock 17 (Tan)</English>
             <French>Glock 17 (Beige)</French>
         </Key>
-        <Key ID="STR_Hgun_Glock17_Black_Display">
+        <Key ID="STR_TACGT_Glock_Glock17_Black_Display">
             <English>Glock 17 (Black)</English>
             <French>Glock 17 (Noir)</French>
         </Key>
-        <Key ID="STR_TACGT_Hgun_Glock18_Tan_Display">
+        <Key ID="STR_TACGT_Glock_Glock18_Tan_Display">
             <English>Glock 18C (Tan)</English>
             <French>Glock 18C (Beige)</French>
         </Key>
-        <Key ID="STR_TACGT_Hgun_Glock18_Black_Display">
+        <Key ID="STR_TACGT_Glock_Glock18_Black_Display">
             <English>Glock 18C (Black)</English>
             <French>Glock 18C (Noir)</French>
         </Key>

--- a/addons/rename/$PBOPREFIX$
+++ b/addons/rename/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\tacgt\addons\rename

--- a/addons/rename/CfgMagazines.hpp
+++ b/addons/rename/CfgMagazines.hpp
@@ -1,0 +1,43 @@
+class CfgMagazines {
+    class CA_Magazine;
+
+    // Vanilla 30Rnd 556 Stanag Magazines
+    class 30Rnd_556x45_Stanag: CA_Magazine {
+        displayName = "$STR_TACGT_Rename_30Rnd_556x45_Stanag_Display";
+    };
+    class 30Rnd_556x45_Stanag_green: 30Rnd_556x45_Stanag {
+        displayName = "$STR_TACGT_Rename_30Rnd_556x45_Stanag_Green_Display";
+    };
+    class 30Rnd_556x45_Stanag_red: 30Rnd_556x45_Stanag {
+        displayName = "$STR_TACGT_Rename_30Rnd_556x45_Stanag_Red_Display";
+    };
+    class 30Rnd_556x45_Stanag_Tracer_Green: 30Rnd_556x45_Stanag {
+        displayName = "$STR_TACGT_Rename_30Rnd_556x45_Stanag_Tracer_Green_Display";
+    };
+    class 30Rnd_556x45_Stanag_Tracer_Red: 30Rnd_556x45_Stanag {
+        displayName = "$STR_TACGT_Rename_30Rnd_556x45_Stanag_Tracer_Red_Display";
+    };
+    class 30Rnd_556x45_Stanag_Tracer_Yellow: 30Rnd_556x45_Stanag {
+        displayName = "$STR_TACGT_Rename_30Rnd_556x45_Stanag_Tracer_Yellow_Display";
+    };
+    
+    // Vanilla 150Rnd 556 Magazines
+    class 150Rnd_556x45_Drum_Mag_F: CA_Magazine {
+        displayName = "$STR_TACGT_Rename_150Rnd_556x45_Drum_Display";
+    };
+    class 150Rnd_556x45_Drum_Sand_Mag_F: 150Rnd_556x45_Drum_Mag_F {
+        displayName = "$STR_TACGT_Rename_150Rnd_556x45_Drum_Sand_Display";
+    };
+    class 150Rnd_556x45_Drum_Sand_Mag_Tracer_F: 150Rnd_556x45_Drum_Sand_Mag_F {
+        displayName = "$STR_TACGT_Rename_150Rnd_556x45_Drum_Sand_Tracer_Display";
+    };
+    class 150Rnd_556x45_Drum_Green_Mag_F: 150Rnd_556x45_Drum_Mag_F {
+        displayName = "$STR_TACGT_Rename_150Rnd_556x45_Drum_Green_Display";
+    };
+    class 150Rnd_556x45_Drum_Green_Mag_Tracer_F: 150Rnd_556x45_Drum_Green_Mag_F {
+        displayName = "$STR_TACGT_Rename_150Rnd_556x45_Drum_Green_Tracer_Display";
+    };
+    class 150Rnd_556x45_Drum_Mag_Tracer_F: 150Rnd_556x45_Drum_Mag_F {
+        displayName = "$STR_TACGT_Rename_150Rnd_556x45_Drum_Tracer_Display";
+    };
+};

--- a/addons/rename/CfgMagazines.hpp
+++ b/addons/rename/CfgMagazines.hpp
@@ -1,7 +1,7 @@
 class CfgMagazines {
     class CA_Magazine;
 
-    // Vanilla 30Rnd 556 Stanag Magazines
+    // 30Rnd 556 Stanag Magazines
     class 30Rnd_556x45_Stanag: CA_Magazine {
         displayName = "$STR_TACGT_Rename_30Rnd_556x45_Stanag_Display";
     };
@@ -21,7 +21,7 @@ class CfgMagazines {
         displayName = "$STR_TACGT_Rename_30Rnd_556x45_Stanag_Tracer_Yellow_Display";
     };
     
-    // Vanilla 150Rnd 556 Magazines
+    // 150Rnd 556 Magazines
     class 150Rnd_556x45_Drum_Mag_F: CA_Magazine {
         displayName = "$STR_TACGT_Rename_150Rnd_556x45_Drum_Display";
     };
@@ -39,5 +39,27 @@ class CfgMagazines {
     };
     class 150Rnd_556x45_Drum_Mag_Tracer_F: 150Rnd_556x45_Drum_Mag_F {
         displayName = "$STR_TACGT_Rename_150Rnd_556x45_Drum_Tracer_Display";
+    };
+    
+    // 200Rnd 556 Box Magazines
+    class 200Rnd_556x45_Box_F: CA_Magazine {
+        displayName = "$STR_TACGT_Rename_200Rnd_556x45_Box_Display";
+    };
+    class 200Rnd_556x45_Box_Red_F: 200Rnd_556x45_Box_F {
+        displayName = "$STR_TACGT_Rename_200Rnd_556x45_Box_Red_Display";
+    };
+    class 200Rnd_556x45_Box_Tracer_F: 200Rnd_556x45_Box_F {
+        displayName = "$STR_TACGT_Rename_200Rnd_556x45_Box_Tracer_Display";
+    };
+    class 200Rnd_556x45_Box_Tracer_Red_F: 200Rnd_556x45_Box_Tracer_F {
+        displayName = "$STR_TACGT_Rename_200Rnd_556x45_Box_Tracer_Red_Display";
+    };
+    
+    // 20Rnd 762 Magazines
+    class 20Rnd_762x51_Mag: CA_Magazine {
+        displayName = "$STR_TACGT_Rename_20Rnd_762x51_Mag";
+    };
+    class ACE_20Rnd_762x51_Mag_Tracer: 20Rnd_762x51_Mag {
+        displayName = "$STR_TACGT_Rename_20Rnd_762x51_Tracer_Mag";
     };
 };

--- a/addons/rename/CfgWeapons.hpp
+++ b/addons/rename/CfgWeapons.hpp
@@ -1,0 +1,18 @@
+class CfgWeapons {
+    class optic_Hamr;
+    class optic_Arco;
+    class optic_MRCO;
+    
+    // ACE 2D Scopes
+    class ACE_optic_Hamr_2D: optic_Hamr {
+        displayName = "$STR_TACGT_Rename_Hamr_2D_Display";
+    };
+    
+    class ACE_optic_Arco_2D: optic_Arco {
+        displayName = "$STR_TACGT_Rename_Arco_2D_Display";
+    };
+    
+    class ACE_optic_MRCO_2D: optic_MRCO {
+        displayName = "$STR_TACGT_Rename_MRCO_2D_Display";
+    };
+};

--- a/addons/rename/README.md
+++ b/addons/rename/README.md
@@ -1,11 +1,20 @@
 # TACGT_Rename
 
-## **Ammunition Designations:**
+### **Abbreviations**
 
-### 5.56x45
+ - [T] Red: "Tracer Red"
+ - [TE4] Red: "Tracers every 4, Red."
+ - [RT] Red: "Reload Tracer, Last 4 are Red M856 Tracer rounds"
+
+### **Ammunition Designations:**
+
+##### 5.56x45
 - M855: Standard ball round.
 - M856: Tracer round matching the same performance as M855.
 - M995: Armour Piercing round.
-- R-Tracer: Reload Tracer, M855 rounds with the last 4 rounds being M856 rounds.
 - MK262: Match-quality round that is more effective at longer ranges than standard M855.
 - MK318: Enhanced variant of the M855, Designed to better penetrate objects with increased consistency.
+
+##### 7.62x51
+- M80: Standard Ball round.
+- M993: Armour Piercing round.

--- a/addons/rename/README.md
+++ b/addons/rename/README.md
@@ -1,0 +1,11 @@
+# TACGT_Rename
+
+## **Ammunition Designations:**
+
+### 5.56x45
+- M855: Standard ball round.
+- M856: Tracer round matching the same performance as M855.
+- M995: Armour Piercing round.
+- R-Tracer: Reload Tracer, M855 rounds with the last 4 rounds being M856 rounds.
+- MK262: Match-quality round that is more effective at longer ranges than standard M855.
+- MK318: Enhanced variant of the M855, Designed to better penetrate objects with increased consistency.

--- a/addons/rename/README.md
+++ b/addons/rename/README.md
@@ -1,4 +1,4 @@
-# TACGT_Rename
+# Rename
 
 ### **Abbreviations**
 

--- a/addons/rename/README.md
+++ b/addons/rename/README.md
@@ -11,6 +11,8 @@
 ##### 5.56x45
 - M855: Standard ball round.
 - M856: Tracer round matching the same performance as M855.
+- M855A1: Enhanced performance round, mid-tier between M855/M995.
+- M856A1: Enhanced performance tracer round.
 - M995: Armour Piercing round.
 - MK262: Match-quality round that is more effective at longer ranges than standard M855.
 - MK318: Enhanced variant of the M855, Designed to better penetrate objects with increased consistency.

--- a/addons/rename/config.cpp
+++ b/addons/rename/config.cpp
@@ -1,0 +1,21 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        magazines[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "tacgt_main"
+        };
+        author = CSTRING(Author);
+        authors[] = {"TyroneMF"};
+        url = CSTRING(URL);
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgWeapons.hpp"
+#include "CfgMagazines.hpp"

--- a/addons/rename/config.cpp
+++ b/addons/rename/config.cpp
@@ -7,9 +7,7 @@ class CfgPatches {
         weapons[] = {};
         magazines[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {
-            "tacgt_main"
-        };
+        requiredAddons[] = {"tacgt_main", "ace_ballistics", "ace_optics"};
         author = CSTRING(Author);
         authors[] = {"TyroneMF"};
         url = CSTRING(URL);

--- a/addons/rename/script_component.hpp
+++ b/addons/rename/script_component.hpp
@@ -1,0 +1,4 @@
+#define COMPONENT rename
+#define COMPONENT_BEAUTIFIED Rename
+#include "\x\tacgt\addons\main\script_mod.hpp"
+#include "\x\tacgt\addons\main\script_macros.hpp"

--- a/addons/rename/stringtable.xml
+++ b/addons/rename/stringtable.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project name="TACGT">
+    <Package name="Rename">
+        <Key ID="STR_TACGT_Rename_30Rnd_556x45_Stanag_Display">
+            <English>5.56mm 30Rnd STANAG (M855)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_30Rnd_556x45_Stanag_Green_Display">
+            <English>5.56mm 30Rnd STANAG R-Tracer Green (M855)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_30Rnd_556x45_Stanag_Red_Display">
+            <English>5.56mm 30Rnd STANAG R-Tracer Red (M855)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_30Rnd_556x45_Stanag_Tracer_Green_Display">
+            <English>5.56mm 30Rnd STANAG Tracer Green (M856)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_30Rnd_556x45_Stanag_Tracer_Red_Display">
+            <English>5.56mm 30Rnd STANAG Tracer Red (M856)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_30Rnd_556x45_Stanag_Tracer_Yellow_Display">
+            <English>5.56mm 30Rnd STANAG Tracer Yellow (M856)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_150Rnd_556x45_Drum_Display">
+            <English>5.56mm 150Rnd Drum Mag (M855)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_150Rnd_556x45_Drum_Sand_Display">
+            <English>5.56mm 150Rnd Sand Drum Mag (M855)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_150Rnd_556x45_Drum_Sand_Tracer_Display">
+            <English>5.56mm 150Rnd Sand T-Red Drum Mag (M856)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_150Rnd_556x45_Drum_Green_Display">
+            <English>5.56mm 150Rnd Green Drum Mag (M855)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_150Rnd_556x45_Drum_Green_Tracer_Display">
+            <English>5.56mm 150Rnd Green T-Red Drum Mag (M856)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_150Rnd_556x45_Drum_Tracer_Display">
+            <English>5.56mm 150Rnd T-Red Drum Mag (M856)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_Hamr_2D_Display">
+            <English>Leupold Mark 4 HAMR (2D)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_Arco_2D_Display">
+            <English>ELCAN SpecterOS (2D)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_MRCO_2D_Display">
+            <English>IOR-Valdada Pitbull 2 (2D)</English>
+        </Key>
+    </Package>
+</Project>

--- a/addons/rename/stringtable.xml
+++ b/addons/rename/stringtable.xml
@@ -5,19 +5,19 @@
             <English>5.56mm 30Rnd STANAG (M855)</English>
         </Key>
         <Key ID="STR_TACGT_Rename_30Rnd_556x45_Stanag_Green_Display">
-            <English>5.56mm 30Rnd STANAG R-Tracer Green (M855)</English>
+            <English>5.56mm 30Rnd STANAG [RT] Green (M855)</English>
         </Key>
         <Key ID="STR_TACGT_Rename_30Rnd_556x45_Stanag_Red_Display">
-            <English>5.56mm 30Rnd STANAG R-Tracer Red (M855)</English>
+            <English>5.56mm 30Rnd STANAG [RT] Red (M855)</English>
         </Key>
         <Key ID="STR_TACGT_Rename_30Rnd_556x45_Stanag_Tracer_Green_Display">
-            <English>5.56mm 30Rnd STANAG Tracer Green (M856)</English>
+            <English>5.56mm 30Rnd STANAG [T] Green (M856)</English>
         </Key>
         <Key ID="STR_TACGT_Rename_30Rnd_556x45_Stanag_Tracer_Red_Display">
-            <English>5.56mm 30Rnd STANAG Tracer Red (M856)</English>
+            <English>5.56mm 30Rnd STANAG [T] Red (M856)</English>
         </Key>
         <Key ID="STR_TACGT_Rename_30Rnd_556x45_Stanag_Tracer_Yellow_Display">
-            <English>5.56mm 30Rnd STANAG Tracer Yellow (M856)</English>
+            <English>5.56mm 30Rnd STANAG [T] Yellow (M856)</English>
         </Key>
         <Key ID="STR_TACGT_Rename_150Rnd_556x45_Drum_Display">
             <English>5.56mm 150Rnd Drum Mag (M855)</English>
@@ -26,16 +26,34 @@
             <English>5.56mm 150Rnd Sand Drum Mag (M855)</English>
         </Key>
         <Key ID="STR_TACGT_Rename_150Rnd_556x45_Drum_Sand_Tracer_Display">
-            <English>5.56mm 150Rnd Sand T-Red Drum Mag (M856)</English>
+            <English>5.56mm 150Rnd Sand [T] Red Drum Mag (M856)</English>
         </Key>
         <Key ID="STR_TACGT_Rename_150Rnd_556x45_Drum_Green_Display">
             <English>5.56mm 150Rnd Green Drum Mag (M855)</English>
         </Key>
         <Key ID="STR_TACGT_Rename_150Rnd_556x45_Drum_Green_Tracer_Display">
-            <English>5.56mm 150Rnd Green T-Red Drum Mag (M856)</English>
+            <English>5.56mm 150Rnd Green [T] Red Drum Mag (M856)</English>
         </Key>
         <Key ID="STR_TACGT_Rename_150Rnd_556x45_Drum_Tracer_Display">
-            <English>5.56mm 150Rnd T-Red Drum Mag (M856)</English>
+            <English>5.56mm 150Rnd [T] Red Drum Mag (M856)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_200Rnd_556x45_Box_Display">
+            <English>5.56mm 200Rnd [TE4] Yellow Box Mag (M855)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_200Rnd_556x45_Box_Red_Display">
+            <English>5.56mm 200Rnd [TE4] Red Box Mag (M855)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_200Rnd_556x45_Box_Tracer_Display">
+            <English>5.56mm 200Rnd [T] Yellow Box Mag (M856)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_200Rnd_556x45_Box_Tracer_Red_Display">
+            <English>5.56mm 200Rnd [T] Red Box Mag (M856)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_20Rnd_762x51_Mag">
+            <English>7.62mm 20Rnd Mag (M80)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_20Rnd_762x51_Tracer_Mag">
+            <English>7.62mm 20Rnd [T] Mag (M62)</English>
         </Key>
         <Key ID="STR_TACGT_Rename_Hamr_2D_Display">
             <English>Leupold Mark 4 HAMR (2D)</English>

--- a/addons/scar/CfgWeapons.hpp
+++ b/addons/scar/CfgWeapons.hpp
@@ -58,221 +58,221 @@ class CfgWeapons {
 
     // MK16 Renaming
     class CUP_arifle_Mk16_STD: CUP_arifle_SCAR_L_Base {
-        displayName = "$STR_SCAR_L_Display";
+        displayName = "$STR_TACGT_Scar_L_Display";
     };
 
     class CUP_arifle_Mk16_STD_black: CUP_arifle_Mk16_STD {
-        displayName = "$STR_SCAR_L_Black_Display";
+        displayName = "$STR_TACGT_Scar_L_Black_Display";
     };
 
     class CUP_arifle_Mk16_STD_woodland: CUP_arifle_Mk16_STD {
-        displayName = "$STR_SCAR_L_Woodland_Display";
+        displayName = "$STR_TACGT_Scar_L_Woodland_Display";
     };
 
     class CUP_arifle_Mk16_STD_FG: CUP_arifle_Mk16_STD {
-        displayName = "$STR_SCAR_L_FG_Display";
+        displayName = "$STR_TACGT_Scar_L_FG_Display";
     };
 
     class CUP_arifle_Mk16_STD_FG_black: CUP_arifle_Mk16_STD_FG {
-        displayName = "$STR_SCAR_L_Black_FG_Display";
+        displayName = "$STR_TACGT_Scar_L_Black_FG_Display";
     };
 
     class CUP_arifle_Mk16_STD_FG_woodland: CUP_arifle_Mk16_STD_FG {
-        displayName = "$STR_SCAR_L_Woodland_FG_Display";
+        displayName = "$STR_TACGT_Scar_L_Woodland_FG_Display";
     };
 
     class CUP_arifle_Mk16_STD_SFG: CUP_arifle_Mk16_STD {
-        displayName = "$STR_SCAR_L_SFG_Display";
+        displayName = "$STR_TACGT_Scar_L_SFG_Display";
     };
 
     class CUP_arifle_Mk16_STD_SFG_black: CUP_arifle_Mk16_STD_SFG {
-        displayName = "$STR_SCAR_L_Black_SFG_Display";
+        displayName = "$STR_TACGT_Scar_L_Black_SFG_Display";
     };
 
     class CUP_arifle_Mk16_STD_SFG_woodland: CUP_arifle_Mk16_STD_SFG {
-        displayName = "$STR_SCAR_L_Woodland_SFG_Display";
+        displayName = "$STR_TACGT_Scar_L_Woodland_SFG_Display";
     };
 
     class CUP_arifle_Mk16_STD_EGLM: CUP_arifle_Mk16_STD {
-        displayName = "$STR_SCAR_L_EGLM_Display";
+        displayName = "$STR_TACGT_Scar_L_EGLM_Display";
         magazineWell[] = {"CBA_556x45_STANAG", "STANAG_556x45", "STANAG_556x45_Large", "CBA_556x45_SCAR_EGLM"};
     };
 
     class CUP_arifle_Mk16_STD_EGLM_black: CUP_arifle_Mk16_STD_EGLM {
-        displayName = "$STR_SCAR_L_Black_EGLM_Display";
+        displayName = "$STR_TACGT_Scar_L_Black_EGLM_Display";
     };
 
     class CUP_arifle_Mk16_STD_EGLM_woodland: CUP_arifle_Mk16_STD_EGLM {
-        displayName = "$STR_SCAR_L_Woodland_EGLM_Display";
+        displayName = "$STR_TACGT_Scar_L_Woodland_EGLM_Display";
     };
 
     class CUP_arifle_Mk16_SV: CUP_arifle_SCAR_L_Base {
-        displayName = "$STR_SCAR_L_MR_Display";
+        displayName = "$STR_TACGT_Scar_L_MR_Display";
     };
 
     class CUP_arifle_Mk16_SV_black: CUP_arifle_Mk16_SV {
-        displayName = "$STR_SCAR_L_Black_MR_Display";
+        displayName = "$STR_TACGT_Scar_L_Black_MR_Display";
     };
 
     class CUP_arifle_Mk16_SV_woodland: CUP_arifle_Mk16_SV {
-        displayName = "$STR_SCAR_L_Woodland_MR_Display";
+        displayName = "$STR_TACGT_Scar_L_Woodland_MR_Display";
     };
 
     class CUP_arifle_Mk16_CQC: CUP_arifle_SCAR_L_Base {
-        displayName = "$STR_SCAR_L_CQC_Display";
+        displayName = "$STR_TACGT_Scar_L_CQC_Display";
     };
 
     class CUP_arifle_Mk16_CQC_black: CUP_arifle_Mk16_CQC {
-        displayName = "$STR_SCAR_L_Black_CQC_Display";
+        displayName = "$STR_TACGT_Scar_L_Black_CQC_Display";
     };
 
     class CUP_arifle_Mk16_CQC_woodland: CUP_arifle_Mk16_CQC {
-        displayName = "$STR_SCAR_L_Woodland_CQC_Display";
+        displayName = "$STR_TACGT_Scar_L_Woodland_CQC_Display";
     };
 
     class CUP_arifle_Mk16_CQC_FG: CUP_arifle_Mk16_CQC {
-        displayName = "$STR_SCAR_L_CQC_FG_Display";
+        displayName = "$STR_TACGT_Scar_L_CQC_FG_Display";
     };
 
     class CUP_arifle_Mk16_CQC_FG_black: CUP_arifle_Mk16_CQC_FG {
-        displayName = "$STR_SCAR_L_Black_CQC_FG_Display";
+        displayName = "$STR_TACGT_Scar_L_Black_CQC_FG_Display";
     };
 
     class CUP_arifle_Mk16_CQC_FG_woodland: CUP_arifle_Mk16_CQC_FG {
-        displayName = "$STR_SCAR_L_Woodland_CQC_FG_Display";
+        displayName = "$STR_TACGT_Scar_L_Woodland_CQC_FG_Display";
     };
 
     class CUP_arifle_Mk16_CQC_SFG: CUP_arifle_Mk16_CQC {
-        displayName = "$STR_SCAR_L_CQC_SFG_Display";
+        displayName = "$STR_TACGT_Scar_L_CQC_SFG_Display";
     };
 
     class CUP_arifle_Mk16_CQC_SFG_black: CUP_arifle_Mk16_CQC_SFG {
-        displayName = "$STR_SCAR_L_Black_CQC_SFG_Display";
+        displayName = "$STR_TACGT_Scar_L_Black_CQC_SFG_Display";
     };
 
     class CUP_arifle_Mk16_CQC_SFG_woodland: CUP_arifle_Mk16_CQC_SFG {
-        displayName = "$STR_SCAR_L_Woodland_CQC_SFG_Display";
+        displayName = "$STR_TACGT_Scar_L_Woodland_CQC_SFG_Display";
     };
 
     class CUP_arifle_Mk16_CQC_EGLM: CUP_arifle_Mk16_CQC {
-        displayName = "$STR_SCAR_L_CQC_EGLM_Display";
+        displayName = "$STR_TACGT_Scar_L_CQC_EGLM_Display";
         magazineWell[] = {"CBA_556x45_STANAG", "STANAG_556x45", "STANAG_556x45_Large", "CBA_556x45_SCAR_EGLM"};
     };
 
     class CUP_arifle_Mk16_CQC_EGLM_black: CUP_arifle_Mk16_CQC_EGLM {
-        displayName = "$STR_SCAR_L_Black_CQC_EGLM_Display";
+        displayName = "$STR_TACGT_Scar_L_Black_CQC_EGLM_Display";
     };
 
     class CUP_arifle_Mk16_CQC_EGLM_woodland: CUP_arifle_Mk16_CQC_EGLM {
-        displayName = "$STR_SCAR_L_Woodland_CQC_EGLM_Display";
+        displayName = "$STR_TACGT_Scar_L_Woodland_CQC_EGLM_Display";
     };
 
     // MK17 Renaming
     class CUP_arifle_Mk17_STD: CUP_arifle_Mk17_Base {
-        displayName = "$STR_SCAR_H_Display";
+        displayName = "$STR_TACGT_Scar_H_Display";
     };
 
     class CUP_arifle_Mk17_STD_black: CUP_arifle_Mk17_STD {
-        displayName = "$STR_SCAR_H_Black_Display";
+        displayName = "$STR_TACGT_Scar_H_Black_Display";
     };
 
     class CUP_arifle_Mk17_STD_woodland: CUP_arifle_Mk17_STD {
-        displayName = "$STR_SCAR_H_Woodland_Display";
+        displayName = "$STR_TACGT_Scar_H_Woodland_Display";
     };
 
     class CUP_arifle_Mk17_STD_FG: CUP_arifle_Mk17_STD {
-        displayName = "$STR_SCAR_H_FG_Display";
+        displayName = "$STR_TACGT_Scar_H_FG_Display";
     };
 
     class CUP_arifle_Mk17_STD_FG_black: CUP_arifle_Mk17_STD_FG {
-        displayName = "$STR_SCAR_H_Black_FG_Display";
+        displayName = "$STR_TACGT_Scar_H_Black_FG_Display";
     };
 
     class CUP_arifle_Mk17_STD_FG_woodland: CUP_arifle_Mk17_STD_FG {
-        displayName = "$STR_SCAR_H_Woodland_FG_Display";
+        displayName = "$STR_TACGT_Scar_H_Woodland_FG_Display";
     };
 
     class CUP_arifle_Mk17_STD_SFG: CUP_arifle_Mk17_STD_FG {
-        displayName = "$STR_SCAR_H_SFG_Display";
+        displayName = "$STR_TACGT_Scar_H_SFG_Display";
     };
 
     class CUP_arifle_Mk17_STD_SFG_black: CUP_arifle_Mk17_STD_SFG {
-        displayName = "$STR_SCAR_H_Black_SFG_Display";
+        displayName = "$STR_TACGT_Scar_H_Black_SFG_Display";
     };
 
     class CUP_arifle_Mk17_STD_SFG_woodland: CUP_arifle_Mk17_STD_SFG {
-        displayName = "$STR_SCAR_H_Woodland_SFG_Display";
+        displayName = "$STR_TACGT_Scar_H_Woodland_SFG_Display";
     };
 
     class CUP_arifle_Mk17_STD_EGLM: CUP_arifle_Mk17_STD {
-        displayName = "$STR_SCAR_H_EGLM_Display";
+        displayName = "$STR_TACGT_Scar_H_EGLM_Display";
     };
 
     class CUP_arifle_Mk17_STD_EGLM_black: CUP_arifle_Mk17_STD_EGLM {
-        displayName = "$STR_SCAR_H_Black_EGLM_Display";
+        displayName = "$STR_TACGT_Scar_H_Black_EGLM_Display";
     };
 
     class CUP_arifle_Mk17_STD_EGLM_woodland: CUP_arifle_Mk17_STD_EGLM {
-        displayName = "$STR_SCAR_H_Woodland_EGLM_Display";
+        displayName = "$STR_TACGT_Scar_H_Woodland_EGLM_Display";
     };
 
     class CUP_arifle_Mk20: CUP_arifle_Mk17_Base {
-        displayName = "$STR_SCAR_H_MR_Display";
+        displayName = "$STR_TACGT_Scar_H_MR_Display";
     };
 
     class CUP_arifle_Mk20_black: CUP_arifle_Mk20 {
-        displayName = "$STR_SCAR_H_Black_MR_Display";
+        displayName = "$STR_TACGT_Scar_H_Black_MR_Display";
     };
 
     class CUP_arifle_Mk20_woodland: CUP_arifle_Mk20 {
-        displayName = "$STR_SCAR_H_Woodland_MR_Display";
+        displayName = "$STR_TACGT_Scar_H_Woodland_MR_Display";
     };
 
     class CUP_arifle_Mk17_CQC: CUP_arifle_Mk17_Base {
-        displayName = "$STR_SCAR_H_CQC_Display";
+        displayName = "$STR_TACGT_Scar_H_CQC_Display";
     };
 
     class CUP_arifle_Mk17_CQC_Black: CUP_arifle_Mk17_CQC {
-        displayName = "$STR_SCAR_H_Black_CQC_Display";
+        displayName = "$STR_TACGT_Scar_H_Black_CQC_Display";
     };
 
     class CUP_arifle_Mk17_CQC_woodland: CUP_arifle_Mk17_CQC {
-        displayName = "$STR_SCAR_H_Woodland_CQC_Display";
+        displayName = "$STR_TACGT_Scar_H_Woodland_CQC_Display";
     };
 
     class CUP_arifle_Mk17_CQC_FG: CUP_arifle_Mk17_CQC {
-        displayName = "$STR_SCAR_H_CQC_FG_Display";
+        displayName = "$STR_TACGT_Scar_H_CQC_FG_Display";
     };
 
     class CUP_arifle_Mk17_CQC_FG_black: CUP_arifle_Mk17_CQC_FG {
-        displayName = "$STR_SCAR_H_Black_CQC_FG_Display";
+        displayName = "$STR_TACGT_Scar_H_Black_CQC_FG_Display";
     };
 
     class CUP_arifle_Mk17_CQC_FG_woodland: CUP_arifle_Mk17_CQC_FG {
-        displayName = "$STR_SCAR_H_Woodland_CQC_FG_Display";
+        displayName = "$STR_TACGT_Scar_H_Woodland_CQC_FG_Display";
     };
 
     class CUP_arifle_Mk17_CQC_SFG: CUP_arifle_Mk17_CQC_FG {
-        displayName = "$STR_SCAR_H_CQC_SFG_Display";
+        displayName = "$STR_TACGT_Scar_H_CQC_SFG_Display";
     };
 
     class CUP_arifle_Mk17_CQC_SFG_black: CUP_arifle_Mk17_CQC_SFG {
-        displayName = "$STR_SCAR_H_Black_CQC_SFG_Display";
+        displayName = "$STR_TACGT_Scar_H_Black_CQC_SFG_Display";
     };
 
     class CUP_arifle_Mk17_CQC_SFG_woodland: CUP_arifle_Mk17_CQC_SFG {
-        displayName = "$STR_SCAR_H_Woodland_CQC_SFG_Display";
+        displayName = "$STR_TACGT_Scar_H_Woodland_CQC_SFG_Display";
     };
 
     class CUP_arifle_Mk17_CQC_EGLM: CUP_arifle_Mk17_CQC {
-        displayName = "$STR_SCAR_H_CQC_EGLM_Display";
+        displayName = "$STR_TACGT_Scar_H_CQC_EGLM_Display";
     };
 
     class CUP_arifle_Mk17_CQC_EGLM_black: CUP_arifle_Mk17_CQC_EGLM {
-        displayName = "$STR_SCAR_H_Black_CQC_EGLM_Display";
+        displayName = "$STR_TACGT_Scar_H_Black_CQC_EGLM_Display";
     };
 
     class CUP_arifle_Mk17_CQC_EGLM_woodland: CUP_arifle_Mk17_CQC_EGLM {
-        displayName = "$STR_SCAR_H_Woodland_CQC_EGLM_Display";
+        displayName = "$STR_TACGT_Scar_H_Woodland_CQC_EGLM_Display";
     };
 };

--- a/addons/scar/stringtable.xml
+++ b/addons/scar/stringtable.xml
@@ -1,219 +1,219 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project name="TACGT">
     <Package name="SCAR">
-        <Key ID="STR_SCAR_L_Display">
+        <Key ID="STR_TACGT_Scar_L_Display">
             <English>SCAR-L</English>
             <French>SCAR-L</French>
         </Key>
-        <Key ID="STR_SCAR_L_Black_Display">
+        <Key ID="STR_TACGT_Scar_L_Black_Display">
             <English>SCAR-L Black</English>
             <French>SCAR-L Noir</French>
         </Key>
-        <Key ID="STR_SCAR_L_Woodland_Display">
+        <Key ID="STR_TACGT_Scar_L_Woodland_Display">
             <English>SCAR-L Woodland</English>
             <French>SCAR-L Des Bois</French>
         </Key>
-        <Key ID="STR_SCAR_L_FG_Display">
+        <Key ID="STR_TACGT_Scar_L_FG_Display">
             <English>SCAR-L (Front Grip)</English>
             <French>SCAR-L (Poignée Avant)</French>
         </Key>
-        <Key ID="STR_SCAR_L_Black_FG_Display">
+        <Key ID="STR_TACGT_Scar_L_Black_FG_Display">
             <English>SCAR-L Black (Front Grip)</English>
             <French>SCAR-L Noir (Poignée Avant)</French>
         </Key>
-        <Key ID="STR_SCAR_L_Woodland_FG_Display">
+        <Key ID="STR_TACGT_Scar_L_Woodland_FG_Display">
             <English>SCAR-L Woodland (Front Grip)</English>
             <French>SCAR-L Des Bois (Poignée Avant)</French>
         </Key>
-        <Key ID="STR_SCAR_L_SFG_Display">
+        <Key ID="STR_TACGT_Scar_L_SFG_Display">
             <English>SCAR-L (Surefire Front Grip)</English>
             <French>SCAR-L (Surefire Poignée Avant)</French>
         </Key>
-        <Key ID="STR_SCAR_L_Black_SFG_Display">
+        <Key ID="STR_TACGT_Scar_L_Black_SFG_Display">
             <English>SCAR-L Black (Surefire Front Grip)</English>
             <French>SCAR-L Noir (Surefire Poignée Avant)</French>
         </Key>
-        <Key ID="STR_SCAR_L_Woodland_SFG_Display">
+        <Key ID="STR_TACGT_Scar_L_Woodland_SFG_Display">
             <English>SCAR-L Woodland (Surefire Front Grip)</English>
             <French>SCAR-L Des Bois (Surefire Poignée Avant)</French>
         </Key>
-        <Key ID="STR_SCAR_L_EGLM_Display">
+        <Key ID="STR_TACGT_Scar_L_EGLM_Display">
             <English>SCAR-L (EGLM)</English>
             <French>SCAR-L (EGLM)</French>
         </Key>
-        <Key ID="STR_SCAR_L_Black_EGLM_Display">
+        <Key ID="STR_TACGT_Scar_L_Black_EGLM_Display">
             <English>SCAR-L Black (EGLM)</English>
             <French>SCAR-L Noir (EGLM)</French>
         </Key>
-        <Key ID="STR_SCAR_L_Woodland_EGLM_Display">
+        <Key ID="STR_TACGT_Scar_L_Woodland_EGLM_Display">
             <English>SCAR-L Woodland (EGLM)</English>
             <French>SCAR-L Des Bois (EGLM)</French>
         </Key>
-        <Key ID="STR_SCAR_L_MR_Display">
+        <Key ID="STR_TACGT_Scar_L_MR_Display">
             <English>SCAR-L MR</English>
             <French>SCAR-L MR</French>
         </Key>
-        <Key ID="STR_SCAR_L_Black_MR_Display">
+        <Key ID="STR_TACGT_Scar_L_Black_MR_Display">
             <English>SCAR-L Black MR</English>
             <French>SCAR-L Noir MR</French>
         </Key>
-        <Key ID="STR_SCAR_L_Woodland_MR_Display">
+        <Key ID="STR_TACGT_Scar_L_Woodland_MR_Display">
             <English>SCAR-L Woodland MR</English>
             <French>SCAR-L Des Bois MR</French>
         </Key>
-        <Key ID="STR_SCAR_L_CQC_Display">
+        <Key ID="STR_TACGT_Scar_L_CQC_Display">
             <English>SCAR-L CQC</English>
             <French>SCAR-L CQC</French>
         </Key>
-        <Key ID="STR_SCAR_L_Black_CQC_Display">
+        <Key ID="STR_TACGT_Scar_L_Black_CQC_Display">
             <English>SCAR-L CQC Black</English>
             <French>SCAR-L CQC Noir</French>
         </Key>
-        <Key ID="STR_SCAR_L_Woodland_CQC_Display">
+        <Key ID="STR_TACGT_Scar_L_Woodland_CQC_Display">
             <English>SCAR-L CQC Woodland</English>
             <French>SCAR-L CQC Des Bois</French>
         </Key>
-        <Key ID="STR_SCAR_L_CQC_FG_Display">
+        <Key ID="STR_TACGT_Scar_L_CQC_FG_Display">
             <English>SCAR-L CQC (Front Grip)</English>
             <French>SCAR-L CQC (Poignée Avant)</French>
         </Key>
-        <Key ID="STR_SCAR_L_Black_CQC_FG_Display">
+        <Key ID="STR_TACGT_Scar_L_Black_CQC_FG_Display">
             <English>SCAR-L CQC Black (Front Grip)</English>
             <French>SCAR-L CQC Noir (Poignée Avant)</French>
         </Key>
-        <Key ID="STR_SCAR_L_Woodland_CQC_FG_Display">
+        <Key ID="STR_TACGT_Scar_L_Woodland_CQC_FG_Display">
             <English>SCAR-L CQC Woodland (Front Grip)</English>
             <French>SCAR-L CQC Des Bois (Poignée Avant)</French>
         </Key>
-        <Key ID="STR_SCAR_L_CQC_SFG_Display">
+        <Key ID="STR_TACGT_Scar_L_CQC_SFG_Display">
             <English>SCAR-L CQC (Surefire Front Grip)</English>
             <French>SCAR-L CQC (Surefire Poignée Avant)</French>
         </Key>
-        <Key ID="STR_SCAR_L_Black_CQC_SFG_Display">
+        <Key ID="STR_TACGT_Scar_L_Black_CQC_SFG_Display">
             <English>SCAR-L CQC Black (Surefire Front Grip)</English>
             <French>SCAR-L CQC Noir (Surefire Poignée Avant)</French>
         </Key>
-        <Key ID="STR_SCAR_L_Woodland_CQC_SFG_Display">
+        <Key ID="STR_TACGT_Scar_L_Woodland_CQC_SFG_Display">
             <English>SCAR-L CQC Woodland (Surefire Front Grip)</English>
             <French>SCAR-L CQC Des Bois (Surefire Poignée Avant)</French>
         </Key>
-        <Key ID="STR_SCAR_L_CQC_EGLM_Display">
+        <Key ID="STR_TACGT_Scar_L_CQC_EGLM_Display">
             <English>SCAR-L CQC (EGLM)</English>
             <French>SCAR-L CQC (EGLM)</French>
         </Key>
-        <Key ID="STR_SCAR_L_Black_CQC_EGLM_Display">
+        <Key ID="STR_TACGT_Scar_L_Black_CQC_EGLM_Display">
             <English>SCAR-L CQC Black (EGLM)</English>
             <French>SCAR-L CQC Noir (EGLM)</French>
         </Key>
-        <Key ID="STR_SCAR_L_Woodland_CQC_EGLM_Display">
+        <Key ID="STR_TACGT_Scar_L_Woodland_CQC_EGLM_Display">
             <English>SCAR-L CQC Woodland (EGLM)</English>
             <French>SCAR-L CQC Des Bois (EGLM)</French>
         </Key>
-        <Key ID="STR_SCAR_H_Display">
+        <Key ID="STR_TACGT_Scar_H_Display">
             <English>SCAR-H</English>
             <French>SCAR-H</French>
         </Key>
-        <Key ID="STR_SCAR_H_Black_Display">
+        <Key ID="STR_TACGT_Scar_H_Black_Display">
             <English>SCAR-H Black</English>
             <French>SCAR-H Noir</French>
         </Key>
-        <Key ID="STR_SCAR_H_Woodland_Display">
+        <Key ID="STR_TACGT_Scar_H_Woodland_Display">
             <English>SCAR-H Woodland</English>
             <French>SCAR-H Des Bois</French>
         </Key>
-        <Key ID="STR_SCAR_H_FG_Display">
+        <Key ID="STR_TACGT_Scar_H_FG_Display">
             <English>SCAR-H (Front Grip)</English>
             <French>SCAR-H (Poignée Avant)</French>
         </Key>
-        <Key ID="STR_SCAR_H_Black_FG_Display">
+        <Key ID="STR_TACGT_Scar_H_Black_FG_Display">
             <English>SCAR-H Black (Front Grip)</English>
             <French>SCAR-H Noir (Poignée Avant)</French>
         </Key>
-        <Key ID="STR_SCAR_H_Woodland_FG_Display">
+        <Key ID="STR_TACGT_Scar_H_Woodland_FG_Display">
             <English>SCAR-H Woodland (Front Grip)</English>
             <French>SCAR-H Des Bois (Poignée Avant)</French>
         </Key>
-        <Key ID="STR_SCAR_H_SFG_Display">
+        <Key ID="STR_TACGT_Scar_H_SFG_Display">
             <English>SCAR-H (Surefire Front Grip)</English>
             <French>SCAR-H (Surefire Poignée Avant)</French>
         </Key>
-        <Key ID="STR_SCAR_H_Black_SFG_Display">
+        <Key ID="STR_TACGT_Scar_H_Black_SFG_Display">
             <English>SCAR-H Black (Surefire Front Grip)</English>
             <French>SCAR-H Noir (Surefire Poignée Avant)</French>
         </Key>
-        <Key ID="STR_SCAR_H_Woodland_SFG_Display">
+        <Key ID="STR_TACGT_Scar_H_Woodland_SFG_Display">
             <English>SCAR-H Woodland (Surefire Front Grip)</English>
             <French>SCAR-H Des Bois (Surefire Poignée Avant)</French>
         </Key>
-        <Key ID="STR_SCAR_H_EGLM_Display">
+        <Key ID="STR_TACGT_Scar_H_EGLM_Display">
             <English>SCAR-H (EGLM)</English>
             <French>SCAR-H (EGLM)</French>
         </Key>
-        <Key ID="STR_SCAR_H_Black_EGLM_Display">
+        <Key ID="STR_TACGT_Scar_H_Black_EGLM_Display">
             <English>SCAR-H Black (EGLM)</English>
             <French>SCAR-H Noir (EGLM)</French>
         </Key>
-        <Key ID="STR_SCAR_H_Woodland_EGLM_Display">
+        <Key ID="STR_TACGT_Scar_H_Woodland_EGLM_Display">
             <English>SCAR-H Woodland (EGLM)</English>
             <French>SCAR-H Des Bois (EGLM)</French>
         </Key>
-        <Key ID="STR_SCAR_H_MR_Display">
+        <Key ID="STR_TACGT_Scar_H_MR_Display">
             <English>SCAR-H MR</English>
             <French>SCAR-H MR</French>
         </Key>
-        <Key ID="STR_SCAR_H_Black_MR_Display">
+        <Key ID="STR_TACGT_Scar_H_Black_MR_Display">
             <English>SCAR-H Black MR</English>
             <French>SCAR-H Noir MR</French>
         </Key>
-        <Key ID="STR_SCAR_H_Woodland_MR_Display">
+        <Key ID="STR_TACGT_Scar_H_Woodland_MR_Display">
             <English>SCAR-H Woodland MR</English>
             <French>SCAR-H Des Bois</French>
         </Key>
-        <Key ID="STR_SCAR_H_CQC_Display">
+        <Key ID="STR_TACGT_Scar_H_CQC_Display">
             <English>SCAR-H CQC</English>
             <French>SCAR-H CQC</French>
         </Key>
-        <Key ID="STR_SCAR_H_Black_CQC_Display">
+        <Key ID="STR_TACGT_Scar_H_Black_CQC_Display">
             <English>SCAR-H Black CQC</English>
             <French>SCAR-H Noir CQC</French>
         </Key>
-        <Key ID="STR_SCAR_H_Woodland_CQC_Display">
+        <Key ID="STR_TACGT_Scar_H_Woodland_CQC_Display">
             <English>SCAR-H Woodland CQC</English>
             <French>SCAR-H Des Bois CQC</French>
         </Key>
-        <Key ID="STR_SCAR_H_CQC_FG_Display">
+        <Key ID="STR_TACGT_Scar_H_CQC_FG_Display">
             <English>SCAR-H CQC (Front Grip)</English>
             <French>SCAR-H CQC (Poignée Avant)</French>
         </Key>
-        <Key ID="STR_SCAR_H_Black_CQC_FG_Display">
+        <Key ID="STR_TACGT_Scar_H_Black_CQC_FG_Display">
             <English>SCAR-H Black CQC (Front Grip)</English>
             <French>SCAR-H Noir CQC (Poignée Avant)</French>
         </Key>
-        <Key ID="STR_SCAR_H_Woodland_CQC_FG_Display">
+        <Key ID="STR_TACGT_Scar_H_Woodland_CQC_FG_Display">
             <English>SCAR-H Woodland CQC (Front Grip)</English>
             <French>SCAR-H Des Bois CQC (Poignée Avant)</French>
         </Key>
-        <Key ID="STR_SCAR_H_CQC_SFG_Display">
+        <Key ID="STR_TACGT_Scar_H_CQC_SFG_Display">
             <English>SCAR-H CQC (Surefire Front Grip)</English>
             <French>SCAR-H CQC (Surefire Poignée Avant)</French>
         </Key>
-        <Key ID="STR_SCAR_H_Black_CQC_SFG_Display">
+        <Key ID="STR_TACGT_Scar_H_Black_CQC_SFG_Display">
             <English>SCAR-H Black CQC (Surefire Front Grip)</English>
             <French>SCAR-H Noir CQC (Surefire Poignée Avant)</French>
         </Key>
-        <Key ID="STR_SCAR_H_Woodland_CQC_SFG_Display">
+        <Key ID="STR_TACGT_Scar_H_Woodland_CQC_SFG_Display">
             <English>SCAR-H Wooddland CQC (Surefire Front Grip)</English>
             <French>SCAR-H Des Bois CQC (Surefire Poignée Avant)</French>
         </Key>
-        <Key ID="STR_SCAR_H_CQC_EGLM_Display">
+        <Key ID="STR_TACGT_Scar_H_CQC_EGLM_Display">
             <English>SCAR-H CQC (EGLM)</English>
             <French>SCAR-H CQC (EGLM)</French>
         </Key>
-        <Key ID="STR_SCAR_H_Black_CQC_EGLM_Display">
+        <Key ID="STR_TACGT_Scar_H_Black_CQC_EGLM_Display">
             <English>SCAR-H Black CQC (EGLM)</English>
             <French>SCAR-H Noir CQC (EGLM)</French>
         </Key>
-        <Key ID="STR_SCAR_H_Woodland_CQC_EGLM_Display">
+        <Key ID="STR_TACGT_Scar_H_Woodland_CQC_EGLM_Display">
             <English>SCAR-H Woodland CQC (EGLM)</English>
             <French>SCAR-H Des Bois CQC (EGLM)</French>
         </Key>


### PR DESCRIPTION
- Start of renaming 5.56 magazines
- Start of 7.62 magazines
- Temporarily rename ACE 2D Optics to the ACE Realistic names format until it's released in ACE.

- Will be sporadically updated with changes over time.