### PR TITLE
Add PMAG/EMAG Variants and Overhaul Ammunition

### DIFF
--- a/addons/ak/CfgSoundSets.hpp
+++ b/addons/ak/CfgSoundSets.hpp
@@ -1,5 +1,5 @@
 class CfgSoundSets {
-    CLASS(AKM_Shot_SoundSet) {
+    class CLASS(AKM_Shot_SoundSet) {
         volumeFactor = 1.6;
         obstructionFactor = 0.3;
         occlusionFactor = 0.5;
@@ -12,7 +12,7 @@ class CfgSoundSets {
         distanceFilter = "weaponShotDistanceFreqAttenuationFilter";
     };
 
-    CLASS(AKM_tail_SoundSet) {
+    class CLASS(AKM_tail_SoundSet) {
         volumeFactor = 1;
         obstructionFactor = 0;
         occlusionFactor = 0.3;
@@ -26,7 +26,7 @@ class CfgSoundSets {
         distanceFilter = "weaponShotTailDistanceFreqAttenuationFilter";
     };
 
-    CLASS(AKM_Silencer_SoundSet) {
+    class CLASS(AKM_Silencer_SoundSet) {
         volumeFactor = 1;
         obstructionFactor = 0.3;
         occlusionFactor = 0.5;
@@ -38,7 +38,7 @@ class CfgSoundSets {
         sound3DProcessingType = "WeaponMediumShotTail3DProcessingType";
     };
 
-    CLASS(AKM_SilencerTail_SoundSet) {
+    class CLASS(AKM_SilencerTail_SoundSet) {
         doppler = 0;
         frequencyRandomizer = 1;
         loop = 0;
@@ -52,7 +52,7 @@ class CfgSoundSets {
         sound3DProcessingType = "WeaponMediumShotTail3DProcessingType";
     };
 
-    CLASS(AK74U_Shot_SoundSet) {
+    class CLASS(AK74U_Shot_SoundSet) {
         doppler = 0;
         loop = 0;
         obstructionFactor = 0.3;
@@ -64,7 +64,7 @@ class CfgSoundSets {
         volumeCurve = "InverseSquare2Curve";
     };
 
-    CLASS(AK74U_tail_SoundSet) {
+    class CLASS(AK74U_tail_SoundSet) {
         doppler = 0;
         frequencyRandomizer = 1;
         loop = 0;
@@ -79,7 +79,7 @@ class CfgSoundSets {
         volumeCurve = "InverseSquare2Curve";
     };
 
-    CLASS(AK74U_Silencer_SoundSet) {
+    class CLASS(AK74U_Silencer_SoundSet) {
         doppler = 0;
         loop = 0;
         obstructionFactor = 0.3;
@@ -91,7 +91,7 @@ class CfgSoundSets {
         soundShaders[] = {"AK74_closure_SoundShader", "AK74_silencerShot_SoundShader"};
     };
 
-    CLASS(AK74U_SilencerTail_SoundSet) {
+    class CLASS(AK74U_SilencerTail_SoundSet) {
         doppler = 0;
         frequencyRandomizer = 1;
         volumeFactor = 0.7;

--- a/addons/ak/config.cpp
+++ b/addons/ak/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacgt_main", "CUP_Weapons_AK"};
         author = CSTRING(Author);
-        authors[] = {"GilleeDoo", "TyroneMF"};
+        authors[] = {"TyroneMF"};
         url = CSTRING(URL);
         VERSION_CONFIG;
     };

--- a/addons/ammunition/CfgAmmo.hpp
+++ b/addons/ammunition/CfgAmmo.hpp
@@ -71,6 +71,6 @@ class CfgAmmo {
     };
 
     class CLASS(556x45_EPR_M855A1_Red): CLASS(556x45_EPR_M855A1) {
-        model="\A3\Weapons_f\Data\bullettracer\tracer_red";
+        model = "\A3\Weapons_f\Data\bullettracer\tracer_red";
     };
 };

--- a/addons/ammunition/CfgAmmo.hpp
+++ b/addons/ammunition/CfgAmmo.hpp
@@ -2,10 +2,10 @@ class CfgAmmo {
     class BulletBase;
     class B_556x45_Ball;
     class B_762x39_Ball_F;
-    class B_12Gauge_Pellets_Submunition: BulletBase {};
-    class B_12Gauge_Pellets_Submunition_Deploy: BulletBase {};
+    class B_12Gauge_Pellets_Submunition;
+    class B_12Gauge_Pellets_Submunition_Deploy;
 
-    CLASS(12g_Pellets_Submunition): B_12Gauge_Pellets_Submunition {
+    class CLASS(12g_Pellets_Submunition): B_12Gauge_Pellets_Submunition {
         caliber = 0.5;
         cost = 1;
         hit = 25;
@@ -17,7 +17,7 @@ class CfgAmmo {
         triggerSpeedCoef[] = {0.85, 1};
         triggerTime = 0.008;
     };
-    CLASS(12g_Pellets_Submunition_Deploy): B_12Gauge_Pellets_Submunition_Deploy {
+    class CLASS(12g_Pellets_Submunition_Deploy): B_12Gauge_Pellets_Submunition_Deploy {
         airFriction = -0.0030;
         caliber = 0.525;
         hit = 8;
@@ -27,7 +27,7 @@ class CfgAmmo {
         deflecting = 35;
     };
 
-    CLASS(S_12G_AP20): BulletBase {
+    class CLASS(S_12G_AP20): BulletBase {
         timetoLive = 6;
         hit = 40;
         indirectHit = 0;
@@ -43,25 +43,31 @@ class CfgAmmo {
         model = "\A3\weapons_f\empty.p3d";
         simulation = "shotBullet";
     };
-    CLASS(P_12G_000): B_12Gauge_Pellets_Submunition {
+    class CLASS(P_12G_000): B_12Gauge_Pellets_Submunition {
         caliber = 0.525;
         submunitionConeType[] = {"random", 12};
         triggerTime = 0.008;
         submunitionAmmo = QCLASS(12g_Pellets_Submunition_Deploy);
         submunitionConeAngle = 0.81;
     };
-    CLASS(556x45_EPR_M855A1): B_556x45_Ball {
-        airFriction=-0.0012588;
-        ACE_caliber=5.69;
-        ACE_bulletLength=23.012;
-        ACE_bulletMass=4.0176;
-        ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
-        ACE_ballisticCoefficients[]={0.307};
-        ACE_velocityBoundaries[]={};
-        ACE_standardAtmosphere="ASM";
-        ACE_dragModel=1;
-        ACE_muzzleVelocities[]={791, 897, 961};
-        ACE_barrelLengths[]={264.0, 393.7, 508.0};
+    class CLASS(556x45_EPR_M855A1): B_556x45_Ball {
+        hit = 10.28;
+        typicalSpeed = 974.8;
+        airFriction = -0.0012744;
+        caliber = 0.964;
+        airFriction = -0.0012588;
+        deflecting = 17;
+        audibleFire = 20;
+        ACE_caliber = 5.69;
+        ACE_bulletLength = 23.012;
+        ACE_bulletMass = 4.0176;
+        ACE_ammoTempMuzzleVelocityShifts[] = {-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
+        ACE_ballisticCoefficients[] = {0.175};
+        ACE_velocityBoundaries[] = {};
+        ACE_standardAtmosphere = "ASM";
+        ACE_dragModel = 1;
+        ACE_muzzleVelocities[] = {723, 764, 796, 825, 843, 866, 878, 892, 906, 915, 922, 900};
+        ACE_barrelLengths[] = {210.82, 238.76, 269.24, 299.72, 330.2, 360.68, 391.16, 419.1, 449.58, 480.06, 508.0, 609.6};
     };
 
     CLASS(556x45_EPR_M855A1_Red): tacgt_556x45_EPR_M855A1 {

--- a/addons/ammunition/CfgAmmo.hpp
+++ b/addons/ammunition/CfgAmmo.hpp
@@ -70,7 +70,7 @@ class CfgAmmo {
         ACE_barrelLengths[] = {210.82, 238.76, 269.24, 299.72, 330.2, 360.68, 391.16, 419.1, 449.58, 480.06, 508.0, 609.6};
     };
 
-    CLASS(556x45_EPR_M855A1_Red): tacgt_556x45_EPR_M855A1 {
+    class CLASS(556x45_EPR_M855A1_Red): CLASS(556x45_EPR_M855A1) {
         model="\A3\Weapons_f\Data\bullettracer\tracer_red";
     };
 };

--- a/addons/ammunition/CfgAmmo.hpp
+++ b/addons/ammunition/CfgAmmo.hpp
@@ -1,5 +1,7 @@
 class CfgAmmo {
     class BulletBase;
+    class B_556x45_Ball;
+    class B_762x39_Ball_F;
     class B_12Gauge_Pellets_Submunition: BulletBase {};
     class B_12Gauge_Pellets_Submunition_Deploy: BulletBase {};
 
@@ -47,5 +49,22 @@ class CfgAmmo {
         triggerTime = 0.008;
         submunitionAmmo = QCLASS(12g_Pellets_Submunition_Deploy);
         submunitionConeAngle = 0.81;
+    };
+    CLASS(556x45_EPR_M855A1): B_556x45_Ball {
+        airFriction=-0.0012588;
+        ACE_caliber=5.69;
+        ACE_bulletLength=23.012;
+        ACE_bulletMass=4.0176;
+        ACE_ammoTempMuzzleVelocityShifts[]={-26.55, -25.47, -22.85, -20.12, -16.98, -12.80, -7.64, -1.53, 5.96, 15.17, 26.19};
+        ACE_ballisticCoefficients[]={0.307};
+        ACE_velocityBoundaries[]={};
+        ACE_standardAtmosphere="ASM";
+        ACE_dragModel=1;
+        ACE_muzzleVelocities[]={791, 897, 961};
+        ACE_barrelLengths[]={264.0, 393.7, 508.0};
+    };
+
+    CLASS(556x45_EPR_M855A1_Red): tacgt_556x45_EPR_M855A1 {
+        model="\A3\Weapons_f\Data\bullettracer\tracer_red";
     };
 };

--- a/addons/ammunition/CfgMagazineWells.hpp
+++ b/addons/ammunition/CfgMagazineWells.hpp
@@ -10,13 +10,34 @@ class CfgMagazineWells {
     class CBA_556x45_STANAG {
         TACGT_mags[] = {
             QCLASS(30Rnd_556x45_M855_PMAG),
+            QCLASS(30Rnd_556x45_M855_PMAG_Tan),
+            QCLASS(30Rnd_556x45_M855A1_PMAG),
+            QCLASS(30Rnd_556x45_M855A1_EMAG),
+            QCLASS(30Rnd_556x45_M855A1_PMAG_Tan),
+            QCLASS(30Rnd_556x45_M855A1_EMAG_Tan),
             QCLASS(30Rnd_556x45_M855_EMAG),
+            QCLASS(30Rnd_556x45_M855_EMAG_Tan),
             QCLASS(30Rnd_556x45_M995_PMAG),
+            QCLASS(30Rnd_556x45_M995_PMAG_Tan),
             QCLASS(30Rnd_556x45_M995_EMAG),
+            QCLASS(30Rnd_556x45_M995_EMAG_Tan),
             QCLASS(30Rnd_556x45_MK262_PMAG),
+            QCLASS(30Rnd_556x45_MK262_PMAG_Tan),
             QCLASS(30Rnd_556x45_MK262_EMAG),
+            QCLASS(30Rnd_556x45_MK262_EMAG_Tan),
             QCLASS(30Rnd_556x45_MK318_PMAG),
-            QCLASS(30Rnd_556x45_MK318_EMAG)
+            QCLASS(30Rnd_556x45_MK318_PMAG_Tan),
+            QCLASS(30Rnd_556x45_MK318_EMAG),
+            QCLASS(30Rnd_556x45_MK318_EMAG_Tan)
+        };
+    };
+    
+    class CBA_556x45_MINIMI {
+        TACGT_mags[] = {
+            QCLASS(200Rnd_556x45_M855A1_Box),
+            QCLASS(200Rnd_556x45_M855A1_Box_Red),
+            QCLASS(200Rnd_556x45_M855A1_Box_Tracer),
+            QCLASS(200Rnd_556x45_M855A1_Box_Tracer_Red)
         };
     };
 };

--- a/addons/ammunition/CfgMagazineWells.hpp
+++ b/addons/ammunition/CfgMagazineWells.hpp
@@ -1,9 +1,9 @@
 class CfgMagazineWells {
-    CLASS(8rnd_12g) {
+    class CLASS(8rnd_12g) {
         TACGT_mags[] = {QCLASS(8Rnd_P_000), QCLASS(8Rnd_S_AP20)};
     };
 
-    CLASS(6rnd_12g) {
+    class CLASS(6rnd_12g) {
         TACGT_mags[] = {QCLASS(6Rnd_P_000), QCLASS(6Rnd_S_AP20)};
     };
     

--- a/addons/ammunition/CfgMagazines.hpp
+++ b/addons/ammunition/CfgMagazines.hpp
@@ -6,7 +6,7 @@ class CfgMagazines {
     class ACE_30Rnd_556x45_Stanag_Mk262_mag;
     class ACE_30Rnd_556x45_Stanag_Mk318_mag;
 
-    CLASS(8Rnd_P_000): CA_Magazine {
+    class CLASS(8Rnd_P_000): CA_Magazine {
         author = "TyroneMF";
         scope = 2;
         displayName = "$STR_TACGT_Ammunition_8Rnd_P_000_Display";
@@ -20,7 +20,7 @@ class CfgMagazines {
         reloadaction = "CUP_GestureReloadM1014_8Rnd";
     };
 
-    CLASS(8Rnd_S_AP20): CA_Magazine {
+    class CLASS(8Rnd_S_AP20): CA_Magazine {
         author = "TyroneMF";
         scope = 2;
         displayName = "$STR_TACGT_Ammunition_8Rnd_S_AP20_Display";
@@ -34,14 +34,14 @@ class CfgMagazines {
         reloadaction = "CUP_GestureReloadM1014_8Rnd";
     };
 
-    CLASS(6Rnd_P_000): tacgt_8Rnd_P_000 {
+    class CLASS(6Rnd_P_000): CLASS(8Rnd_P_000) {
         displayName = "$STR_TACGT_Ammunition_6Rnd_P_000_Display";
         displayNameShort = "$STR_TACGT_Ammunition_8Rnd_P_000_Display_Short";
         count = 6;
         mass = 6;
     };
 
-    CLASS(6Rnd_S_AP20): tacgt_8Rnd_S_AP20 {
+    class CLASS(6Rnd_S_AP20): CLASS(8Rnd_S_AP20) {
         displayName = "$STR_TACGT_Ammunition_6Rnd_S_AP20_Display";
         displayNameShort = "$STR_TACGT_Ammunition_8Rnd_S_AP20_Display_Short";
         count = 6;
@@ -50,7 +50,7 @@ class CfgMagazines {
 
     // 556 30Rnd Magazines
     // PMAG
-    CLASS(30Rnd_556x45_M855_PMAG): 30Rnd_556x45_Stanag_green {
+    class CLASS(30Rnd_556x45_M855_PMAG): 30Rnd_556x45_Stanag_green {
         author = "TyroneMF";
         scope = 2;
         lastRoundsTracer = 4;
@@ -64,20 +64,20 @@ class CfgMagazines {
         hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\pmag_black_co.paa"};
     };
 
-    CLASS(30Rnd_556x45_M855_PMAG_Tan): tacgt_30Rnd_556x45_M855_PMAG {
+    class CLASS(30Rnd_556x45_M855_PMAG_Tan): CLASS(30Rnd_556x45_M855_PMAG) {
         picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_pmag_coyote_ca.paa";
         displayName = "$STR_TACGT_Ammunition_30Rnd_556x45_M855_PMAG_Tan_Display";
         hiddenSelections[] = {"Camo1"};
         hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\pmag_coyote_co.paa"};
     };
 
-    CLASS(30Rnd_556x45_M855A1_PMAG): 30Rnd_556x45_Stanag_green {
+    class CLASS(30Rnd_556x45_M855A1_PMAG): 30Rnd_556x45_Stanag_green {
         author = "TyroneMF";
         scope = 2;
         lastRoundsTracer = 4;
         picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_pmag_ca.paa";
         displayName = "$STR_TACGT_Ammunition_30Rnd_556x45_M855A1_PMAG_Display";
-        ammo = "tacgt_556x45_EPR_M855A1";
+        ammo = QCLASS(556x45_EPR_M855A1);
         mass = 10;
         model = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines\CUP_mag_30rnd_pmag_qp.p3d";
         modelSpecial = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines_proxy\CUP_mag_30rnd_pmag_qp.p3d";
@@ -86,14 +86,14 @@ class CfgMagazines {
         hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\pmag_black_co.paa"};
     };
 
-    CLASS(30Rnd_556x45_M855A1_PMAG_Tan): tacgt_30Rnd_556x45_M855A1_PMAG {
+    class CLASS(30Rnd_556x45_M855A1_PMAG_Tan): CLASS(30Rnd_556x45_M855A1_PMAG) {
         picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_pmag_coyote_ca.paa";
         displayName = "$STR_TACGT_Ammunition_30Rnd_556x45_M855A1_PMAG_Tan_Display";
         hiddenSelections[] = {"Camo1"};
         hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\pmag_coyote_co.paa"};
     };
 
-    CLASS(30Rnd_556x45_M995_PMAG): ACE_30Rnd_556x45_Stanag_M995_AP_mag {
+    class CLASS(30Rnd_556x45_M995_PMAG): ACE_30Rnd_556x45_Stanag_M995_AP_mag {
         author = "TyroneMF";
         scope = 2;
         lastRoundsTracer = 2;
@@ -107,14 +107,14 @@ class CfgMagazines {
         hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\pmag_black_co.paa"};
     };
 
-    CLASS(30Rnd_556x45_M995_PMAG_Tan): tacgt_30Rnd_556x45_M995_PMAG {
+    class CLASS(30Rnd_556x45_M995_PMAG_Tan): CLASS(30Rnd_556x45_M995_PMAG) {
         picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_pmag_coyote_ca.paa";
         displayName = "$STR_TACGT_Ammunition_30Rnd_556x45_M995_PMAG_Tan_Display";
         hiddenSelections[] = {"Camo1"};
         hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\pmag_coyote_co.paa"};
     };
 
-    CLASS(30Rnd_556x45_MK262_PMAG): ACE_30Rnd_556x45_Stanag_Mk262_mag {
+    class CLASS(30Rnd_556x45_MK262_PMAG): ACE_30Rnd_556x45_Stanag_Mk262_mag {
         author = "TyroneMF";
         scope = 2;
         lastRoundsTracer = 2;
@@ -128,14 +128,14 @@ class CfgMagazines {
         hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\pmag_black_co.paa"};
     };
 
-    CLASS(30Rnd_556x45_MK262_PMAG_Tan): tacgt_30Rnd_556x45_MK262_PMAG {
+    class CLASS(30Rnd_556x45_MK262_PMAG_Tan): CLASS(30Rnd_556x45_MK262_PMAG) {
         picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_pmag_coyote_ca.paa";
         displayName = "$STR_TACGT_Ammunition_30Rnd_556x45_MK262_PMAG_Tan_Display";
         hiddenSelections[] = {"Camo1"};
         hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\pmag_coyote_co.paa"};
     };
 
-    CLASS(30Rnd_556x45_MK318_PMAG): ACE_30Rnd_556x45_Stanag_Mk318_mag {
+    class CLASS(30Rnd_556x45_MK318_PMAG): ACE_30Rnd_556x45_Stanag_Mk318_mag {
         author = "TyroneMF";
         scope = 2;
         lastRoundsTracer = 2;
@@ -149,7 +149,7 @@ class CfgMagazines {
         hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\pmag_black_co.paa"};
     };
 
-    CLASS(30Rnd_556x45_MK318_PMAG_Tan): tacgt_30Rnd_556x45_MK318_PMAG {
+    class CLASS(30Rnd_556x45_MK318_PMAG_Tan): CLASS(30Rnd_556x45_MK318_PMAG) {
         picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_pmag_coyote_ca.paa";
         displayName = "$STR_TACGT_Ammunition_30Rnd_556x45_MK318_PMAG_Tan_Display";
         hiddenSelections[] = {"Camo1"};
@@ -157,7 +157,7 @@ class CfgMagazines {
     };
 
     // EMAG
-    CLASS(30Rnd_556x45_M855_EMAG): 30Rnd_556x45_Stanag_green {
+    class CLASS(30Rnd_556x45_M855_EMAG): 30Rnd_556x45_Stanag_green {
         author = "TyroneMF";
         scope = 2;
         lastRoundsTracer = 4;
@@ -171,20 +171,20 @@ class CfgMagazines {
         hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\emag_co.paa"};
     };
 
-    CLASS(30Rnd_556x45_M855_EMAG_Tan): tacgt_30Rnd_556x45_M855_EMAG {
+    class CLASS(30Rnd_556x45_M855_EMAG_Tan): CLASS(30Rnd_556x45_M855_EMAG) {
         picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_emag_coyote_ca.paa";
         displayName = "$STR_TACGT_Ammunition_30Rnd_556x45_M855_EMAG_Tan_Display";
         model = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines\CUP_mag_30Rnd_EMAG_coyote.p3d";
         hiddenSelections[] = {"Camo1"};
         hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\emag_coyote_co.paa"}; 
     };
-    CLASS(30Rnd_556x45_M855A1_EMAG): 30Rnd_556x45_Stanag_green {
+    class CLASS(30Rnd_556x45_M855A1_EMAG): 30Rnd_556x45_Stanag_green {
         author = "TyroneMF";
         scope = 2;
         lastRoundsTracer = 4;
         picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_emag_ca.paa";
         displayName = "$STR_TACGT_Ammunition_30Rnd_556x45_M855A1_EMAG_Display";
-        ammo = "tacgt_556x45_EPR_M855A1";
+        ammo = QCLASS(556x45_EPR_M855A1);
         mass = 10;
         model = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines\CUP_mag_30Rnd_EMAG.p3d";
         modelSpecial = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines_proxy\CUP_mag_30Rnd_EMAG.p3d";
@@ -193,7 +193,7 @@ class CfgMagazines {
         hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\emag_co.paa"};
     };
     
-    CLASS(30Rnd_556x45_M855A1_EMAG_Tan): tacgt_30Rnd_556x45_M855A1_EMAG {
+    class CLASS(30Rnd_556x45_M855A1_EMAG_Tan): CLASS(30Rnd_556x45_M855A1_EMAG) {
         picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_emag_coyote_ca.paa";
         displayName = "$STR_TACGT_Ammunition_30Rnd_556x45_M855A1_EMAG_Tan_Display";
         model = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines\CUP_mag_30Rnd_EMAG_coyote.p3d";
@@ -201,7 +201,7 @@ class CfgMagazines {
         hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\emag_coyote_co.paa"}; 
     };
     
-    CLASS(30Rnd_556x45_M995_EMAG): ACE_30Rnd_556x45_Stanag_M995_AP_mag {
+    class CLASS(30Rnd_556x45_M995_EMAG): ACE_30Rnd_556x45_Stanag_M995_AP_mag {
         author = "TyroneMF";
         scope = 2;
         lastRoundsTracer = 2;
@@ -215,7 +215,7 @@ class CfgMagazines {
         hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\emag_co.paa"};
     };
 
-    CLASS(30Rnd_556x45_M995_EMAG_Tan): tacgt_30Rnd_556x45_M995_EMAG {
+    class CLASS(30Rnd_556x45_M995_EMAG_Tan): CLASS(30Rnd_556x45_M995_EMAG) {
         picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_emag_coyote_ca.paa";
         displayName = "$STR_TACGT_Ammunition_30Rnd_556x45_M995_EMAG_Tan_Display";
         model = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines\CUP_mag_30Rnd_EMAG_coyote.p3d";
@@ -223,7 +223,7 @@ class CfgMagazines {
         hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\emag_coyote_co.paa"};
     };
 
-    CLASS(30Rnd_556x45_MK262_EMAG): ACE_30Rnd_556x45_Stanag_Mk262_mag {
+    class CLASS(30Rnd_556x45_MK262_EMAG): ACE_30Rnd_556x45_Stanag_Mk262_mag {
         author = "TyroneMF";
         scope = 2;
         lastRoundsTracer = 2;
@@ -237,7 +237,7 @@ class CfgMagazines {
         hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\emag_co.paa"};
     };
 
-    CLASS(30Rnd_556x45_MK262_EMAG_Tan): tacgt_30Rnd_556x45_MK262_EMAG {
+    class CLASS(30Rnd_556x45_MK262_EMAG_Tan): CLASS(30Rnd_556x45_MK262_EMAG) {
         picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_emag_coyote_ca.paa";
         displayName = "$STR_TACGT_Ammunition_30Rnd_556x45_MK262_EMAG_Tan_Display";
         model = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines\CUP_mag_30Rnd_EMAG_coyote.p3d";
@@ -245,7 +245,7 @@ class CfgMagazines {
         hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\emag_coyote_co.paa"};
     };
 
-    CLASS(30Rnd_556x45_MK318_EMAG): ACE_30Rnd_556x45_Stanag_Mk318_mag {
+    class CLASS(30Rnd_556x45_MK318_EMAG): ACE_30Rnd_556x45_Stanag_Mk318_mag {
         author = "TyroneMF";
         scope = 2;
         lastRoundsTracer = 2;
@@ -259,7 +259,7 @@ class CfgMagazines {
         hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\emag_co.paa"};
     };
 
-    CLASS(30Rnd_556x45_MK318_EMAG_Tan): tacgt_30Rnd_556x45_MK318_EMAG {
+    class CLASS(30Rnd_556x45_MK318_EMAG_Tan): CLASS(30Rnd_556x45_MK318_EMAG) {
         picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_emag_coyote_ca.paa";
         displayName = "$STR_TACGT_Ammunition_30Rnd_556x45_MK318_EMAG_Tan_Display";
         model = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines\CUP_mag_30Rnd_EMAG_coyote.p3d";
@@ -268,30 +268,30 @@ class CfgMagazines {
     };
 
     // 200Rnd 556 Box Magazines
-    CLASS(200Rnd_556x45_M855A1_Box): 200Rnd_556x45_Box_F {
+    class CLASS(200Rnd_556x45_M855A1_Box): 200Rnd_556x45_Box_F {
         author = "TyroneMF";
         scope = 2;
         displayName = "$STR_TACGT_Ammunition_200Rnd_556x45_M855A1_Box_Display";
-        ammo = "tacgt_556x45_EPR_M855A1";
+        ammo = QCLASS(556x45_EPR_M855A1);
         mass = 40;
         tracersEvery = 4;
     };
     
-    CLASS(200Rnd_556x45_M855A1_Box_Red): tacgt_200Rnd_556x45_M855A1_Box {
+    class CLASS(200Rnd_556x45_M855A1_Box_Red): CLASS(200Rnd_556x45_M855A1_Box) {
         displayName = "$STR_TACGT_Ammunition_200Rnd_556x45_M855A1_Box_Red_Display";
-        ammo = "tacgt_556x45_EPR_M855A1_Red";
+        ammo = QCLASS(556x45_EPR_M855A1_Red);
         tracersEvery = 4;
     };
     
-    CLASS(200Rnd_556x45_M855A1_Box_Tracer): tacgt_200Rnd_556x45_M855A1_Box {
+    class CLASS(200Rnd_556x45_M855A1_Box_Tracer): CLASS(200Rnd_556x45_M855A1_Box) {
         displayName = "$STR_TACGT_Ammunition_200Rnd_556x45_M855A1_Box_Tracer_Display";
-        ammo = "tacgt_556x45_EPR_M855A1";
+        ammo = QCLASS(556x45_EPR_M855A1);
         tracersEvery = 1;
     };
     
-    CLASS(200Rnd_556x45_M855A1_Box_Tracer_Red): tacgt_200Rnd_556x45_M855A1_Box_Tracer {
+    class CLASS(200Rnd_556x45_M855A1_Box_Tracer_Red): CLASS(200Rnd_556x45_M855A1_Box_Tracer) {
         displayName = "$STR_TACGT_Ammunition_200Rnd_556x45_M855A1_Box_Tracer_Red_Display";
-        ammo = "tacgt_556x45_EPR_M855A1_Red";
+        ammo = QCLASS(556x45_EPR_M855A1_Red);
         tracersEvery = 1;
     };
 };

--- a/addons/ammunition/CfgMagazines.hpp
+++ b/addons/ammunition/CfgMagazines.hpp
@@ -1,6 +1,7 @@
 class CfgMagazines {
     class CA_Magazine;
     class 30Rnd_556x45_Stanag_green;
+    class 200Rnd_556x45_Box_F;
     class ACE_30Rnd_556x45_Stanag_M995_AP_mag;
     class ACE_30Rnd_556x45_Stanag_Mk262_mag;
     class ACE_30Rnd_556x45_Stanag_Mk318_mag;
@@ -8,13 +9,13 @@ class CfgMagazines {
     CLASS(8Rnd_P_000): CA_Magazine {
         author = "TyroneMF";
         scope = 2;
-        displayName = "$STR_Ammunition_TACGT_8Rnd_P_000_Display";
-        displayNameShort = "$STR_Ammunition_TACGT_8Rnd_P_000_Display_Short";
+        displayName = "$STR_TACGT_Ammunition_8Rnd_P_000_Display";
+        displayNameShort = "$STR_TACGT_Ammunition_8Rnd_P_000_Display_Short";
         ammo = QCLASS(P_12G_000);
         count = 8;
         initSpeed = 385;
         picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_12gauge_ca.paa";
-        descriptionShort = "$STR_Ammunition_TACGT_8Rnd_P_000_Description";
+        descriptionShort = "$STR_TACGT_Ammunition_8Rnd_P_000_Description";
         mass = 8;
         reloadaction = "CUP_GestureReloadM1014_8Rnd";
     };
@@ -22,43 +23,74 @@ class CfgMagazines {
     CLASS(8Rnd_S_AP20): CA_Magazine {
         author = "TyroneMF";
         scope = 2;
-        displayName = "$STR_Ammunition_TACGT_8Rnd_S_AP20_Display";
-        displayNameShort = "$STR_Ammunition_TACGT_8Rnd_S_AP20_Display_Short";
+        displayName = "$STR_TACGT_Ammunition_8Rnd_S_AP20_Display";
+        displayNameShort = "$STR_TACGT_Ammunition_8Rnd_S_AP20_Display_Short";
         ammo = QCLASS(S_12G_AP20);
         count = 8;
         initSpeed = 510;
         picture = "\a3\Weapons_F_Enoch\MagazineProxies\data\UI\icon_2rnd_12gauge_slugs_CA.paa";
-        descriptionShort = "$STR_Ammunition_TACGT_8Rnd_S_AP20_Description";
+        descriptionShort = "$STR_TACGT_Ammunition_8Rnd_S_AP20_Description";
         mass = 8;
         reloadaction = "CUP_GestureReloadM1014_8Rnd";
     };
 
     CLASS(6Rnd_P_000): tacgt_8Rnd_P_000 {
-        displayName = "$STR_Ammunition_TACGT_6Rnd_P_000_Display";
-        displayNameShort = "$STR_Ammunition_TACGT_8Rnd_P_000_Display_Short";
+        displayName = "$STR_TACGT_Ammunition_6Rnd_P_000_Display";
+        displayNameShort = "$STR_TACGT_Ammunition_8Rnd_P_000_Display_Short";
         count = 6;
         mass = 6;
     };
 
     CLASS(6Rnd_S_AP20): tacgt_8Rnd_S_AP20 {
-        displayName = "$STR_Ammunition_TACGT_6Rnd_S_AP20_Display";
-        displayNameShort = "$STR_Ammunition_TACGT_8Rnd_S_AP20_Display_Short";
+        displayName = "$STR_TACGT_Ammunition_6Rnd_S_AP20_Display";
+        displayNameShort = "$STR_TACGT_Ammunition_8Rnd_S_AP20_Display_Short";
         count = 6;
         mass = 6;
     };
 
+    // 556 30Rnd Magazines
+    // PMAG
     CLASS(30Rnd_556x45_M855_PMAG): 30Rnd_556x45_Stanag_green {
         author = "TyroneMF";
         scope = 2;
         lastRoundsTracer = 4;
         picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_pmag_ca.paa";
-        displayName = "$STR_Ammunition_TACGT_30Rnd_556x45_M855_PMAG_Display";
+        displayName = "$STR_TACGT_Ammunition_30Rnd_556x45_M855_PMAG_Display";
         mass = 10;
         model = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines\CUP_mag_30rnd_pmag_qp.p3d";
         modelSpecial = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines_proxy\CUP_mag_30rnd_pmag_qp.p3d";
         modelSpecialIsProxy = 1;
         hiddenSelections[] = {"Camo1"};
         hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\pmag_black_co.paa"};
+    };
+
+    CLASS(30Rnd_556x45_M855_PMAG_Tan): tacgt_30Rnd_556x45_M855_PMAG {
+        picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_pmag_coyote_ca.paa";
+        displayName = "$STR_TACGT_Ammunition_30Rnd_556x45_M855_PMAG_Tan_Display";
+        hiddenSelections[] = {"Camo1"};
+        hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\pmag_coyote_co.paa"};
+    };
+
+    CLASS(30Rnd_556x45_M855A1_PMAG): 30Rnd_556x45_Stanag_green {
+        author = "TyroneMF";
+        scope = 2;
+        lastRoundsTracer = 4;
+        picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_pmag_ca.paa";
+        displayName = "$STR_TACGT_Ammunition_30Rnd_556x45_M855A1_PMAG_Display";
+        ammo = "tacgt_556x45_EPR_M855A1";
+        mass = 10;
+        model = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines\CUP_mag_30rnd_pmag_qp.p3d";
+        modelSpecial = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines_proxy\CUP_mag_30rnd_pmag_qp.p3d";
+        modelSpecialIsProxy = 1;
+        hiddenSelections[] = {"Camo1"};
+        hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\pmag_black_co.paa"};
+    };
+
+    CLASS(30Rnd_556x45_M855A1_PMAG_Tan): tacgt_30Rnd_556x45_M855A1_PMAG {
+        picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_pmag_coyote_ca.paa";
+        displayName = "$STR_TACGT_Ammunition_30Rnd_556x45_M855A1_PMAG_Tan_Display";
+        hiddenSelections[] = {"Camo1"};
+        hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\pmag_coyote_co.paa"};
     };
 
     CLASS(30Rnd_556x45_M995_PMAG): ACE_30Rnd_556x45_Stanag_M995_AP_mag {
@@ -66,13 +98,20 @@ class CfgMagazines {
         scope = 2;
         lastRoundsTracer = 2;
         picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_pmag_ca.paa";
-        displayName = "$STR_Ammunition_TACGT_30Rnd_556x45_M995_PMAG_Display";
+        displayName = "$STR_TACGT_Ammunition_30Rnd_556x45_M995_PMAG_Display";
         mass = 10;
         model = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines\CUP_mag_30rnd_pmag_qp.p3d";
         modelSpecial = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines_proxy\CUP_mag_30rnd_pmag_qp.p3d";
         modelSpecialIsProxy = 1;
         hiddenSelections[] = {"Camo1"};
         hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\pmag_black_co.paa"};
+    };
+
+    CLASS(30Rnd_556x45_M995_PMAG_Tan): tacgt_30Rnd_556x45_M995_PMAG {
+        picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_pmag_coyote_ca.paa";
+        displayName = "$STR_TACGT_Ammunition_30Rnd_556x45_M995_PMAG_Tan_Display";
+        hiddenSelections[] = {"Camo1"};
+        hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\pmag_coyote_co.paa"};
     };
 
     CLASS(30Rnd_556x45_MK262_PMAG): ACE_30Rnd_556x45_Stanag_Mk262_mag {
@@ -80,13 +119,20 @@ class CfgMagazines {
         scope = 2;
         lastRoundsTracer = 2;
         picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_pmag_ca.paa";
-        displayName = "$STR_Ammunition_TACGT_30Rnd_556x45_MK262_PMAG_Display";
+        displayName = "$STR_TACGT_Ammunition_30Rnd_556x45_MK262_PMAG_Display";
         mass = 10;
         model = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines\CUP_mag_30rnd_pmag_qp.p3d";
         modelSpecial = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines_proxy\CUP_mag_30rnd_pmag_qp.p3d";
         modelSpecialIsProxy = 1;
         hiddenSelections[] = {"Camo1"};
         hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\pmag_black_co.paa"};
+    };
+
+    CLASS(30Rnd_556x45_MK262_PMAG_Tan): tacgt_30Rnd_556x45_MK262_PMAG {
+        picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_pmag_coyote_ca.paa";
+        displayName = "$STR_TACGT_Ammunition_30Rnd_556x45_MK262_PMAG_Tan_Display";
+        hiddenSelections[] = {"Camo1"};
+        hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\pmag_coyote_co.paa"};
     };
 
     CLASS(30Rnd_556x45_MK318_PMAG): ACE_30Rnd_556x45_Stanag_Mk318_mag {
@@ -94,7 +140,7 @@ class CfgMagazines {
         scope = 2;
         lastRoundsTracer = 2;
         picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_pmag_ca.paa";
-        displayName = "$STR_Ammunition_TACGT_30Rnd_556x45_MK318_PMAG_Display";
+        displayName = "$STR_TACGT_Ammunition_30Rnd_556x45_MK318_PMAG_Display";
         mass = 10;
         model = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines\CUP_mag_30rnd_pmag_qp.p3d";
         modelSpecial = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines_proxy\CUP_mag_30rnd_pmag_qp.p3d";
@@ -103,12 +149,20 @@ class CfgMagazines {
         hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\pmag_black_co.paa"};
     };
 
+    CLASS(30Rnd_556x45_MK318_PMAG_Tan): tacgt_30Rnd_556x45_MK318_PMAG {
+        picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_pmag_coyote_ca.paa";
+        displayName = "$STR_TACGT_Ammunition_30Rnd_556x45_MK318_PMAG_Tan_Display";
+        hiddenSelections[] = {"Camo1"};
+        hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\pmag_coyote_co.paa"};
+    };
+
+    // EMAG
     CLASS(30Rnd_556x45_M855_EMAG): 30Rnd_556x45_Stanag_green {
         author = "TyroneMF";
         scope = 2;
         lastRoundsTracer = 4;
         picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_emag_ca.paa";
-        displayName = "$STR_Ammunition_TACGT_30Rnd_556x45_M855_EMAG_Display";
+        displayName = "$STR_TACGT_Ammunition_30Rnd_556x45_M855_EMAG_Display";
         mass = 10;
         model = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines\CUP_mag_30Rnd_EMAG.p3d";
         modelSpecial = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines_proxy\CUP_mag_30Rnd_EMAG.p3d";
@@ -117,12 +171,42 @@ class CfgMagazines {
         hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\emag_co.paa"};
     };
 
+    CLASS(30Rnd_556x45_M855_EMAG_Tan): tacgt_30Rnd_556x45_M855_EMAG {
+        picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_emag_coyote_ca.paa";
+        displayName = "$STR_TACGT_Ammunition_30Rnd_556x45_M855_EMAG_Tan_Display";
+        model = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines\CUP_mag_30Rnd_EMAG_coyote.p3d";
+        hiddenSelections[] = {"Camo1"};
+        hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\emag_coyote_co.paa"}; 
+    };
+    CLASS(30Rnd_556x45_M855A1_EMAG): 30Rnd_556x45_Stanag_green {
+        author = "TyroneMF";
+        scope = 2;
+        lastRoundsTracer = 4;
+        picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_emag_ca.paa";
+        displayName = "$STR_TACGT_Ammunition_30Rnd_556x45_M855A1_EMAG_Display";
+        ammo = "tacgt_556x45_EPR_M855A1";
+        mass = 10;
+        model = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines\CUP_mag_30Rnd_EMAG.p3d";
+        modelSpecial = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines_proxy\CUP_mag_30Rnd_EMAG.p3d";
+        modelSpecialIsProxy = 1;
+        hiddenSelections[] = {"Camo1"};
+        hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\emag_co.paa"};
+    };
+    
+    CLASS(30Rnd_556x45_M855A1_EMAG_Tan): tacgt_30Rnd_556x45_M855A1_EMAG {
+        picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_emag_coyote_ca.paa";
+        displayName = "$STR_TACGT_Ammunition_30Rnd_556x45_M855A1_EMAG_Tan_Display";
+        model = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines\CUP_mag_30Rnd_EMAG_coyote.p3d";
+        hiddenSelections[] = {"Camo1"};
+        hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\emag_coyote_co.paa"}; 
+    };
+    
     CLASS(30Rnd_556x45_M995_EMAG): ACE_30Rnd_556x45_Stanag_M995_AP_mag {
         author = "TyroneMF";
         scope = 2;
         lastRoundsTracer = 2;
         picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_emag_ca.paa";
-        displayName = "$STR_Ammunition_TACGT_30Rnd_556x45_M995_EMAG_Display";
+        displayName = "$STR_TACGT_Ammunition_30Rnd_556x45_M995_EMAG_Display";
         mass = 10;
         model = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines\CUP_mag_30Rnd_EMAG.p3d";
         modelSpecial = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines_proxy\CUP_mag_30Rnd_EMAG.p3d";
@@ -131,12 +215,20 @@ class CfgMagazines {
         hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\emag_co.paa"};
     };
 
-    CLASS(30Rnd_556X45_MK262_EMAG): ACE_30Rnd_556x45_Stanag_Mk262_mag {
+    CLASS(30Rnd_556x45_M995_EMAG_Tan): tacgt_30Rnd_556x45_M995_EMAG {
+        picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_emag_coyote_ca.paa";
+        displayName = "$STR_TACGT_Ammunition_30Rnd_556x45_M995_EMAG_Tan_Display";
+        model = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines\CUP_mag_30Rnd_EMAG_coyote.p3d";
+        hiddenSelections[] = {"Camo1"};
+        hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\emag_coyote_co.paa"};
+    };
+
+    CLASS(30Rnd_556x45_MK262_EMAG): ACE_30Rnd_556x45_Stanag_Mk262_mag {
         author = "TyroneMF";
         scope = 2;
         lastRoundsTracer = 2;
         picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_emag_ca.paa";
-        displayName = "$STR_Ammunition_TACGT_30Rnd_556X45_MK262_EMAG_Display";
+        displayName = "$STR_TACGT_Ammunition_30Rnd_556x45_MK262_EMAG_Display";
         mass = 10;
         model = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines\CUP_mag_30Rnd_EMAG.p3d";
         modelSpecial = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines_proxy\CUP_mag_30Rnd_EMAG.p3d";
@@ -145,17 +237,61 @@ class CfgMagazines {
         hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\emag_co.paa"};
     };
 
-    CLASS(30Rnd_556X45_MK318_EMAG): ACE_30Rnd_556x45_Stanag_Mk318_mag {
+    CLASS(30Rnd_556x45_MK262_EMAG_Tan): tacgt_30Rnd_556x45_MK262_EMAG {
+        picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_emag_coyote_ca.paa";
+        displayName = "$STR_TACGT_Ammunition_30Rnd_556x45_MK262_EMAG_Tan_Display";
+        model = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines\CUP_mag_30Rnd_EMAG_coyote.p3d";
+        hiddenSelections[] = {"Camo1"};
+        hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\emag_coyote_co.paa"};
+    };
+
+    CLASS(30Rnd_556x45_MK318_EMAG): ACE_30Rnd_556x45_Stanag_Mk318_mag {
         author = "TyroneMF";
         scope = 2;
         lastRoundsTracer = 2;
         picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_emag_ca.paa";
-        displayName = "$STR_Ammunition_TACGT_30Rnd_556X45_MK318_EMAG_Display";
+        displayName = "$STR_TACGT_Ammunition_30Rnd_556x45_MK318_EMAG_Display";
         mass = 10;
         model = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines\CUP_mag_30Rnd_EMAG.p3d";
         modelSpecial = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines_proxy\CUP_mag_30Rnd_EMAG.p3d";
         modelSpecialIsProxy = 1;
         hiddenSelections[] = {"Camo1"};
         hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\emag_co.paa"};
+    };
+
+    CLASS(30Rnd_556x45_MK318_EMAG_Tan): tacgt_30Rnd_556x45_MK318_EMAG {
+        picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_emag_coyote_ca.paa";
+        displayName = "$STR_TACGT_Ammunition_30Rnd_556x45_MK318_EMAG_Tan_Display";
+        model = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines\CUP_mag_30Rnd_EMAG_coyote.p3d";
+        hiddenSelections[] = {"Camo1"};
+        hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\emag_coyote_co.paa"};
+    };
+
+    // 200Rnd 556 Box Magazines
+    CLASS(200Rnd_556x45_M855A1_Box): 200Rnd_556x45_Box_F {
+        author = "TyroneMF";
+        scope = 2;
+        displayName = "$STR_TACGT_Ammunition_200Rnd_556x45_M855A1_Box_Display";
+        ammo = "tacgt_556x45_EPR_M855A1";
+        mass = 40;
+        tracersEvery = 4;
+    };
+    
+    CLASS(200Rnd_556x45_M855A1_Box_Red): tacgt_200Rnd_556x45_M855A1_Box {
+        displayName = "$STR_TACGT_Ammunition_200Rnd_556x45_M855A1_Box_Red_Display";
+        ammo = "tacgt_556x45_EPR_M855A1_Red";
+        tracersEvery = 4;
+    };
+    
+    CLASS(200Rnd_556x45_M855A1_Box_Tracer): tacgt_200Rnd_556x45_M855A1_Box {
+        displayName = "$STR_TACGT_Ammunition_200Rnd_556x45_M855A1_Box_Tracer_Display";
+        ammo = "tacgt_556x45_EPR_M855A1";
+        tracersEvery = 1;
+    };
+    
+    CLASS(200Rnd_556x45_M855A1_Box_Tracer_Red): tacgt_200Rnd_556x45_M855A1_Box_Tracer {
+        displayName = "$STR_TACGT_Ammunition_200Rnd_556x45_M855A1_Box_Tracer_Red_Display";
+        ammo = "tacgt_556x45_EPR_M855A1_Red";
+        tracersEvery = 1;
     };
 };

--- a/addons/ammunition/config.cpp
+++ b/addons/ammunition/config.cpp
@@ -6,42 +6,42 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ace_ballistics", "CUP_Weapons_Ammunition", "tacgt_main"};
+        requiredAddons[] = {"tacgt_main", "ace_ballistics", "CUP_Weapons_Ammunition"};
         magazines[] = {
-            "tacgt_8Rnd_P_000",
-            "tacgt_6Rnd_P_000",
-            "tacgt_8Rnd_S_AP20",
-            "tacgt_6Rnd_S_AP20",
-            "tacgt_30Rnd_556x45_M855_PMAG",
-            "tacgt_30Rnd_556x45_M855_PMAG_Tan",
-            "tacgt_30Rnd_556x45_M855A1_PMAG",
-            "tacgt_30Rnd_556x45_M855A1_PMAG_Tan",
-            "tacgt_30Rnd_556x45_M995_PMAG",
-            "tacgt_30Rnd_556x45_M995_PMAG_Tan",
-            "tacgt_30Rnd_556x45_MK262_PMAG",
-            "tacgt_30Rnd_556x45_MK262_PMAG_Tan",
-            "tacgt_30Rnd_556x45_MK318_PMAG",
-            "tacgt_30Rnd_556x45_MK318_PMAG_Tan",
-            "tacgt_30Rnd_556x45_M855_EMAG",
-            "tacgt_30Rnd_556x45_M855_EMAG_Tan",
-            "tacgt_30Rnd_556x45_M855A1_EMAG",
-            "tacgt_30Rnd_556x45_M855A1_EMAG_Tan",
-            "tacgt_30Rnd_556x45_M995_EMAG",
-            "tacgt_30Rnd_556x45_M995_EMAG_Tan",
-            "tacgt_30Rnd_556x45_MK262_EMAG",
-            "tacgt_30Rnd_556x45_MK262_EMAG_Tan",
-            "tacgt_30Rnd_556x45_MK318_EMAG",
-            "tacgt_30Rnd_556x45_MK318_EMAG_Tan",
-            "tacgt_200Rnd_556x45_M855A1_Box",
-            "tacgt_200Rnd_556x45_M855A1_Box_Red",
-            "tacgt_200Rnd_556x45_M855A1_Box_Tracer",
-            "tacgt_200Rnd_556x45_M855A1_Box_Tracer_Red"
+            QCLASS(8Rnd_P_000),
+            QCLASS(6Rnd_P_000),
+            QCLASS(8Rnd_S_AP20),
+            QCLASS(6Rnd_S_AP20),
+            QCLASS(30Rnd_556x45_M855_PMAG),
+            QCLASS(30Rnd_556x45_M855_PMAG_Tan),
+            QCLASS(30Rnd_556x45_M855A1_PMAG),
+            QCLASS(30Rnd_556x45_M855A1_PMAG_Tan),
+            QCLASS(30Rnd_556x45_M995_PMAG),
+            QCLASS(30Rnd_556x45_M995_PMAG_Tan),
+            QCLASS(30Rnd_556x45_MK262_PMAG),
+            QCLASS(30Rnd_556x45_MK262_PMAG_Tan),
+            QCLASS(30Rnd_556x45_MK318_PMAG),
+            QCLASS(30Rnd_556x45_MK318_PMAG_Tan),
+            QCLASS(30Rnd_556x45_M855_EMAG),
+            QCLASS(30Rnd_556x45_M855_EMAG_Tan),
+            QCLASS(30Rnd_556x45_M855A1_EMAG),
+            QCLASS(30Rnd_556x45_M855A1_EMAG_Tan),
+            QCLASS(30Rnd_556x45_M995_EMAG),
+            QCLASS(30Rnd_556x45_M995_EMAG_Tan),
+            QCLASS(30Rnd_556x45_MK262_EMAG),
+            QCLASS(30Rnd_556x45_MK262_EMAG_Tan),
+            QCLASS(30Rnd_556x45_MK318_EMAG),
+            QCLASS(30Rnd_556x45_MK318_EMAG_Tan),
+            QCLASS(200Rnd_556x45_M855A1_Box),
+            QCLASS(200Rnd_556x45_M855A1_Box_Red),
+            QCLASS(200Rnd_556x45_M855A1_Box_Tracer),
+            QCLASS(200Rnd_556x45_M855A1_Box_Tracer_Red)
         };
         ammo[] = {
-            "tacgt_S_12G_AP20",
-            "tacgt_P_12G_000",
-            "tacgt_556x45_EPR_M855A1",
-            "tacgt_556x45_EPR_M855A1_Red"
+            QCLASS(S_12G_AP20),
+            QCLASS(P_12G_000),
+            QCLASS(556x45_EPR_M855A1),
+            QCLASS(556x45_EPR_M855A1_Red)
         };
         author = CSTRING(Author);
         authors[] = {"TyroneMF"};

--- a/addons/ammunition/config.cpp
+++ b/addons/ammunition/config.cpp
@@ -13,20 +13,38 @@ class CfgPatches {
             "tacgt_8Rnd_S_AP20",
             "tacgt_6Rnd_S_AP20",
             "tacgt_30Rnd_556x45_M855_PMAG",
+            "tacgt_30Rnd_556x45_M855_PMAG_Tan",
+            "tacgt_30Rnd_556x45_M855A1_PMAG",
+            "tacgt_30Rnd_556x45_M855A1_PMAG_Tan",
             "tacgt_30Rnd_556x45_M995_PMAG",
+            "tacgt_30Rnd_556x45_M995_PMAG_Tan",
             "tacgt_30Rnd_556x45_MK262_PMAG",
+            "tacgt_30Rnd_556x45_MK262_PMAG_Tan",
             "tacgt_30Rnd_556x45_MK318_PMAG",
+            "tacgt_30Rnd_556x45_MK318_PMAG_Tan",
             "tacgt_30Rnd_556x45_M855_EMAG",
+            "tacgt_30Rnd_556x45_M855_EMAG_Tan",
+            "tacgt_30Rnd_556x45_M855A1_EMAG",
+            "tacgt_30Rnd_556x45_M855A1_EMAG_Tan",
             "tacgt_30Rnd_556x45_M995_EMAG",
+            "tacgt_30Rnd_556x45_M995_EMAG_Tan",
             "tacgt_30Rnd_556x45_MK262_EMAG",
-            "tacgt_30Rnd_556x45_MK318_EMAG"
+            "tacgt_30Rnd_556x45_MK262_EMAG_Tan",
+            "tacgt_30Rnd_556x45_MK318_EMAG",
+            "tacgt_30Rnd_556x45_MK318_EMAG_Tan",
+            "tacgt_200Rnd_556x45_M855A1_Box",
+            "tacgt_200Rnd_556x45_M855A1_Box_Red",
+            "tacgt_200Rnd_556x45_M855A1_Box_Tracer",
+            "tacgt_200Rnd_556x45_M855A1_Box_Tracer_Red"
         };
         ammo[] = {
             "tacgt_S_12G_AP20",
-            "tacgt_P_12G_000"
+            "tacgt_P_12G_000",
+            "tacgt_556x45_EPR_M855A1",
+            "tacgt_556x45_EPR_M855A1_Red"
         };
         author = CSTRING(Author);
-        authors[] = {"GilleeDoo", "TyroneMF"};
+        authors[] = {"TyroneMF"};
         url = CSTRING(URL);
         VERSION_CONFIG;
     };

--- a/addons/ammunition/stringtable.xml
+++ b/addons/ammunition/stringtable.xml
@@ -1,61 +1,109 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project name="TACGT">
     <Package name="Ammunition">
-        <Key ID="STR_Ammunition_TACGT_8Rnd_P_000_Display">
+        <Key ID="STR_TACGT_Ammunition_8Rnd_P_000_Display">
             <English>8Rnd #00 Magnum Shells</English>
             <French>8Rnd #000 Cartouches de chevrotine</French>
         </Key>
-        <Key ID="STR_Ammunition_TACGT_8Rnd_P_000_Display_Short">
+        <Key ID="STR_TACGT_Ammunition_8Rnd_P_000_Display_Short">
             <English>#00 Magnum Shells</English>
             <French>#000 Cartouches de chevrotine</French>
         </Key>
-        <Key ID="STR_Ammunition_TACGT_8Rnd_P_000_Description">
+        <Key ID="STR_TACGT_Ammunition_8Rnd_P_000_Description">
             <English>#000 Buckshot</English>
             <French>#000 Chevrotine</French>
         </Key>
-        <Key ID="STR_Ammunition_TACGT_8Rnd_S_AP20_Display">
+        <Key ID="STR_TACGT_Ammunition_8Rnd_S_AP20_Display">
             <English>8Rnd AP-20 Slug</English>
             <French>8Rnd Limace AP-20</French>
         </Key>
-        <Key ID="STR_Ammunition_TACGT_8Rnd_S_AP20_Display_Short">
+        <Key ID="STR_TACGT_Ammunition_8Rnd_S_AP20_Display_Short">
             <English>AP-20 Slug</English>
             <French>Limace AP-20</French>
         </Key>
-        <Key ID="STR_Ammunition_TACGT_8Rnd_S_AP20_Description">
+        <Key ID="STR_TACGT_Ammunition_8Rnd_S_AP20_Description">
             <English>AP-20 Slugs for precise armour penetration</English>
             <French>Les balles AP-20 pour une pénétration précise du blindage</French>
         </Key>
-        <Key ID="STR_Ammunition_TACGT_6Rnd_P_000_Display">
+        <Key ID="STR_TACGT_Ammunition_6Rnd_P_000_Display">
             <English>6Rnd #00 Magnum Shells</English>
             <French>6Rnd #000 Cartouches de chevrotine</French>
         </Key>
-        <Key ID="STR_Ammunition_TACGT_6Rnd_S_AP20_Display">
+        <Key ID="STR_TACGT_Ammunition_6Rnd_S_AP20_Display">
             <English>6Rnd AP-20 Slug</English>
             <French>6Rnd Limace AP-20</French>
         </Key>
-        <Key ID="STR_Ammunition_TACGT_30Rnd_556x45_M855_PMAG_Display">
-            <English>5.56mm 30Rnd PMAG (M855)</English>
+        <Key ID="STR_TACGT_Ammunition_30Rnd_556x45_M855_PMAG_Display">
+            <English>5.56mm 30Rnd PMAG [RT] Green (M855)</English>
         </Key>
-        <Key ID="STR_Ammunition_TACGT_30Rnd_556x45_M995_PMAG_Display">
+        <Key ID="STR_TACGT_Ammunition_30Rnd_556x45_M855_PMAG_Tan_Display">
+            <English>5.56mm 30Rnd PMAG Tan [RT] Green (M855)</English>
+        </Key>
+        <Key ID="STR_TACGT_Ammunition_30Rnd_556x45_M855A1_PMAG_Display">
+            <English>5.56mm 30Rnd PMAG [RT] Yellow (M855A1)</English>
+        </Key>
+        <Key ID="STR_TACGT_Ammunition_30Rnd_556x45_M855A1_PMAG_Tan_Display">
+            <English>5.56mm 30Rnd PMAG Tan [RT] Yellow (M855A1)</English>
+        </Key>
+        <Key ID="STR_TACGT_Ammunition_30Rnd_556x45_M995_PMAG_Display">
             <English>5.56mm 30Rnd PMAG (M995)</English>
         </Key>
-        <Key ID="STR_Ammunition_TACGT_30Rnd_556x45_MK262_PMAG_Display">
+        <Key ID="STR_TACGT_Ammunition_30Rnd_556x45_M995_PMAG_Tan_Display">
+            <English>5.56mm 30Rnd PMAG Tan (M995)</English>
+        </Key>
+        <Key ID="STR_TACGT_Ammunition_30Rnd_556x45_MK262_PMAG_Display">
             <English>5.56mm 30Rnd PMAG (MK262)</English>
         </Key>
-        <Key ID="STR_Ammunition_TACGT_30Rnd_556x45_MK318_PMAG_Display">
+        <Key ID="STR_TACGT_Ammunition_30Rnd_556x45_MK262_PMAG_Tan_Display">
+            <English>5.56mm 30Rnd PMAG Tan (MK262)</English>
+        </Key>
+        <Key ID="STR_TACGT_Ammunition_30Rnd_556x45_MK318_PMAG_Display">
             <English>5.56mm 30Rnd PMAG (MK318)</English>
         </Key>
-        <Key ID="STR_Ammunition_TACGT_30Rnd_556x45_M855_EMAG_Display">
-            <English>5.56mm 30Rnd EMAG (M855)</English>
+        <Key ID="STR_TACGT_Ammunition_30Rnd_556x45_MK318_PMAG_Tan_Display">
+            <English>5.56mm 30Rnd PMAG Tan (MK318)</English>
         </Key>
-        <Key ID="STR_Ammunition_TACGT_30Rnd_556x45_M995_EMAG_Display">
+        <Key ID="STR_TACGT_Ammunition_30Rnd_556x45_M855_EMAG_Display">
+            <English>5.56mm 30Rnd EMAG [RT] Green (M855)</English>
+        </Key>
+        <Key ID="STR_TACGT_Ammunition_30Rnd_556x45_M855_EMAG_Tan_Display">
+            <English>5.56mm 30Rnd EMAG Tan [RT] Green (M855)</English>
+        </Key>
+        <Key ID="STR_TACGT_Ammunition_30Rnd_556x45_M855A1_EMAG_Display">
+            <English>5.56mm 30Rnd EMAG [RT] Yellow (M855A1)</English>
+        </Key>
+        <Key ID="STR_TACGT_Ammunition_30Rnd_556x45_M855A1_EMAG_Tan_Display">
+            <English>5.56mm 30Rnd EMAG Tan [RT] Yellow (M855A1)</English>
+        </Key>
+        <Key ID="STR_TACGT_Ammunition_30Rnd_556x45_M995_EMAG_Display">
             <English>5.56mm 30Rnd EMAG (M995)</English>
         </Key>
-        <Key ID="STR_Ammunition_TACGT_30Rnd_556X45_MK262_EMAG_Display">
+        <Key ID="STR_TACGT_Ammunition_30Rnd_556x45_M995_EMAG_Tan_Display">
+            <English>5.56mm 30Rnd EMAG Tan (M995)</English>
+        </Key>
+        <Key ID="STR_TACGT_Ammunition_30Rnd_556x45_MK262_EMAG_Display">
             <English>5.56mm 30Rnd EMAG (MK262)</English>
         </Key>
-        <Key ID="STR_Ammunition_TACGT_30Rnd_556X45_MK318_EMAG_Display">
+        <Key ID="STR_TACGT_Ammunition_30Rnd_556x45_MK262_EMAG_Tan_Display">
+            <English>5.56mm 30Rnd EMAG Tan (MK262)</English>
+        </Key>
+        <Key ID="STR_TACGT_Ammunition_30Rnd_556x45_MK318_EMAG_Display">
             <English>5.56mm 30Rnd EMAG (MK318)</English>
+        </Key>
+        <Key ID="STR_TACGT_Ammunition_30Rnd_556x45_MK318_EMAG_Tan_Display">
+            <English>5.56mm 30Rnd EMAG Tan (MK318)</English>
+        </Key>
+        <Key ID="STR_TACGT_Ammunition_200Rnd_556x45_M855A1_Box_Display">
+            <English>5.56mm 200Rnd [TE4] Yellow Box Mag (M855A1)</English>
+        </Key>
+        <Key ID="STR_TACGT_Ammunition_200Rnd_556x45_M855A1_Box_Red_Display">
+            <English>5.56mm 200Rnd [TE4] Red Box Mag (M855A1)</English>
+        </Key>
+        <Key ID="STR_TACGT_Ammunition_200Rnd_556x45_M855A1_Box_Tracer_Display">
+            <English>5.56mm 200Rnd [T] Yellow Box Mag (M856A1)</English>
+        </Key>
+        <Key ID="STR_TACGT_Ammunition_200Rnd_556x45_M855A1_Box_Tracer_Red_Display">
+            <English>5.56mm 200Rnd [T] Red Box Mag (M856A1)</English>
         </Key>
     </Package>
 </Project>

--- a/addons/glock/CfgWeapons.hpp
+++ b/addons/glock/CfgWeapons.hpp
@@ -10,7 +10,7 @@ class CfgWeapons {
         displayName = "$STR_TACGT_Glock_Glock17_Black_Display";
     };
 
-    CLASS(hgun_Glock18_Tan): CUP_hgun_Glock17_tan {
+    class CLASS(hgun_Glock18_Tan): CUP_hgun_Glock17_tan {
         author = "CUP, TyroneMF";
         scope = 2;
         displayName = "$STR_TACGT_Glock_Glock18_Tan_Display";
@@ -55,7 +55,7 @@ class CfgWeapons {
         };
     };
 
-    CLASS(hgun_Glock18_Black): tacgt_hgun_Glock18_Tan {
+    class CLASS(hgun_Glock18_Black): CLASS(hgun_Glock18_Tan) {
         scope = 2;
         displayName = "$STR_TACGT_Glock_Glock18_Black_Display";
         hiddenSelections[] = {"Camo"};

--- a/addons/glock/config.cpp
+++ b/addons/glock/config.cpp
@@ -5,13 +5,13 @@ class CfgPatches {
         name = COMPONENT_NAME;
         units[] = {};
         weapons[] = {
-            "tacgt_hgun_Glock18_Tan",
-            "tacgt_hgun_Glock18_Black"
+            QCLASS(hgun_Glock18_Tan),
+            QCLASS(hgun_Glock18_Black)
         };
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacgt_main", "CUP_Weapons_Glock17"};
         author = CSTRING(Author);
-        authors[] = {"CUP", "GilleeDoo", "TyroneMF"};
+        authors[] = {"CUP", "TyroneMF"};
         url = CSTRING(URL);
         VERSION_CONFIG;
     };

--- a/addons/l85/config.cpp
+++ b/addons/l85/config.cpp
@@ -9,7 +9,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacgt_main", "CUP_Weapons_L85"};
         author = CSTRING(Author);
-        authors[] = {"GilleeDoo", "TyroneMF"};
+        authors[] = {"TyroneMF"};
         url = CSTRING(URL);
         VERSION_CONFIG;
     };

--- a/addons/m1014/CfgSoundSets.hpp
+++ b/addons/m1014/CfgSoundSets.hpp
@@ -1,5 +1,5 @@
 class CfgSoundSets {
-    CLASS(sgun_LB_Shot_SoundSet) {
+    class CLASS(sgun_LB_Shot_SoundSet) {
         soundShaders[] = {"TACGT_sgun_closeShot_SoundShader", "TACGT_sgun_closeShotCenter_SoundShader", "TACGT_sgun_distShot_SoundShader"};
         volumeFactor = 0.9;
         obstructionFactor = 0.3;
@@ -11,7 +11,7 @@ class CfgSoundSets {
         sound3DProcessingType = "WeaponMediumShot3DProcessingType";
         distanceFilter = "weaponShotDistanceFreqAttenuationFilter";
     };
-    CLASS(sgun_LB_tail_SoundSet) {
+    class CLASS(sgun_LB_tail_SoundSet) {
         soundShaders[] = {"TACGT_sgun_tailForest_SoundShader", "TACGT_sgun_tailHouses_SoundShader", "TACGT_sgun_tailInt_SoundShader", "TACGT_sgun_tailMeadows_SoundShader", "TACGT_sgun_tailUrban_SoundShader"};
         volumeFactor = "1.25* 0.9";
         obstructionFactor = 0;
@@ -24,7 +24,7 @@ class CfgSoundSets {
         sound3DProcessingType = "WeaponMediumShotTail3DProcessingType";
         distanceFilter = "weaponShotTailDistanceFreqAttenuationFilter";
     };
-    CLASS(sgun_SB_Shot_SoundSet) {
+    class CLASS(sgun_SB_Shot_SoundSet) {
         soundShaders[] = {"TACGT_sgun_closeShot_SoundShader", "TACGT_sgun_closeShotCenter_SoundShader", "TACGT_sgun_distShot_SoundShader"};
         volumeFactor = 1.1;
         obstructionFactor = 0.3;
@@ -36,7 +36,7 @@ class CfgSoundSets {
         sound3DProcessingType = "WeaponMediumShot3DProcessingType";
         distanceFilter = "weaponShotDistanceFreqAttenuationFilter";
     };
-    CLASS(sgun_SB_tail_SoundSet) {
+    class CLASS(sgun_SB_tail_SoundSet) {
         soundShaders[] = {"TACGT_sgun_tailForest_SoundShader", "TACGT_sgun_tailHouses_SoundShader", "TACGT_sgun_tailInt_SoundShader", "TACGT_sgun_tailMeadows_SoundShader", "TACGT_sgun_tailUrban_SoundShader"};
         volumeFactor = "1.5* 0.9";
         obstructionFactor = 0;

--- a/addons/m1014/CfgSoundShaders.hpp
+++ b/addons/m1014/CfgSoundShaders.hpp
@@ -1,26 +1,26 @@
 class CfgSoundshaders {
-    CLASS(sgun_closeShot_SoundShader) {
+    class CLASS(sgun_closeShot_SoundShader) {
         samples[] = {{"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Shot_Close_01",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Shot_Close_02",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Shot_Close_03",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Shot_Close_04",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Shot_Close_05",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Shot_Close_06",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Shot_Close_07",1}};
         volume = 1.0;
         range = 200;
         rangeCurve = "closeShotCurve";
     };
     
-    CLASS(sgun_closeShotCenter_SoundShader) {
+    class CLASS(sgun_closeShotCenter_SoundShader) {
         samples[] = {{"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Shot_Close_Center_01",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Shot_Close_Center_02",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Shot_Close_Center_03",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Shot_Close_Center_04",1}};
         volume = 1.9;
         range = 25;
         rangeCurve = "closeShotCurve";
     };
     
-    CLASS(sgun_distShot_SoundShader) {
+    class CLASS(sgun_distShot_SoundShader) {
         samples[] = {{"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Shot_Distant_01",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Shot_Distant_01",2}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Shot_Distant_01",3}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Shot_Distant_01",4}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Shot_Distant_01",5}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Shot_Distant_01",6}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Shot_Distant_01",7}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Shot_Distant_01",8}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Shot_Distant_01",9}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Shot_Distant_01",10}};
         volume = 0.6;
         range = 2000;
         rangeCurve[] = {{0,0}, {100,0.5}, {300,1}, {1500,1}, {2000,0}};
     };
 
-    CLASS(sgun_tailForest_SoundShader) {
+    class CLASS(sgun_tailForest_SoundShader) {
         samples[] = {{"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Flutter_01",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Flutter_02",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Flutter_03",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Flutter_04",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Flutter_05",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Flutter_06",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Flutter_07",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Flutter_08",1}};
         volume = "(1-interior/1.4)*forest/2";
         range = 2000;
@@ -28,7 +28,7 @@ class CfgSoundshaders {
         limitation = 1;
     };
 
-    CLASS(sgun_tailHouses_SoundShader) {
+    class CLASS(sgun_tailHouses_SoundShader) {
         samples[] = {{"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Flutter_01",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Flutter_02",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Flutter_03",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Flutter_04",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Flutter_05",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Flutter_06",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Flutter_07",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Flutter_08",1}};
         volume = "(1-interior/1.4)*houses/2";
         range = 2000;
@@ -36,7 +36,7 @@ class CfgSoundshaders {
         limitation = 1;
     };
 
-    CLASS(sgun_tailInt_SoundShader) {
+    class CLASS(sgun_tailInt_SoundShader) {
         samples[] = {{"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Int_01",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Int_02",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Int_03",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Int_04",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Int_05",1}};
         volume = "1.3 * interior";
         range = 60;
@@ -44,7 +44,7 @@ class CfgSoundshaders {
         limitation = 1;
     };
 
-    CLASS(sgun_tailMeadows_SoundShader) {
+    class CLASS(sgun_tailMeadows_SoundShader) {
         samples[] = {{"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Open_01",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Open_02",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Open_03",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Open_04",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Open_05",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Open_06",1}};
         volume = "1 * (1-interior/1.4) * (1-forest)";
         range = 2000;
@@ -52,7 +52,7 @@ class CfgSoundshaders {
         limitation = 1;
     };
 
-    CLASS(sgun_tailUrban_SoundShader) {
+    class CLASS(sgun_tailUrban_SoundShader) {
         samples[] = {{"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Urban_01",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Urban_02",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Urban_03",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Urban_04",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Urban_05",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Urban_06",1}, {"A3\Sounds_F_Enoch\Assets\Arsenal\Msbs65_01\Shotgun\Msbs65_01_Shotgun_Tail_Urban_07",1}};
         volume = "1 * (1-forest)* (1.4-interior/1.4)*houses/2";
         range = 100;

--- a/addons/m1014/config.cpp
+++ b/addons/m1014/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacgt_main", "tacgt_ammunition", "CUP_Weapons_M1014"};
         author = CSTRING(Author);
-        authors[] = {"GilleeDoo", "TyroneMF"};
+        authors[] = {"TyroneMF"};
         url = CSTRING(URL);
         VERSION_CONFIG;
     };

--- a/addons/main/script_macros.hpp
+++ b/addons/main/script_macros.hpp
@@ -8,5 +8,5 @@
 #define VERSION_CONFIG version = MAJOR.MINOR; versionStr = QUOTE(MAJOR.MINOR.PATCH.BUILD); versionAr[] = {MAJOR,MINOR,PATCH,BUILD}
 
 // Class
-#define CLASS(var1) class DOUBLES(PREFIX,var1)
+#define CLASS(var1) DOUBLES(PREFIX,var1)
 #define QCLASS(var1) QUOTE(DOUBLES(PREFIX,var1))

--- a/addons/mp5/CfgMagazineWells.hpp
+++ b/addons/mp5/CfgMagazineWells.hpp
@@ -1,5 +1,5 @@
 class CfgMagazineWells {
-    CLASS(9x19_MP5) {
+    class CLASS(9x19_MP5) {
         // Edit of CBA_9x19_MP5, Removes broken vanilla magwell models
         TACGT_NIA_mags[] = {
             "hlc_30Rnd_9x19_B_MP5",
@@ -11,7 +11,7 @@ class CfgMagazineWells {
             //30Rnd_9x21_Mag_SMG_02_Tracer_Green
         };
     };
-    CLASS(10x25_MP5) {
+    class CLASS(10x25_MP5) {
         TACGT_NIA_mags[] = {
             "hlc_30Rnd_10mm_B_MP5",
             "hlc_30Rnd_10mm_JHP_MP5"

--- a/addons/mp5/config.cpp
+++ b/addons/mp5/config.cpp
@@ -9,7 +9,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacgt_main", "hlcweapons_mp5",};
         author = CSTRING(Author);
-        authors[] = {"GilleeDoo", "TyroneMF"};
+        authors[] = {"TyroneMF"};
         url = CSTRING(URL);
         VERSION_CONFIG;
     };

--- a/addons/mp5/config.cpp
+++ b/addons/mp5/config.cpp
@@ -7,7 +7,7 @@ class CfgPatches {
         weapons[] = {};
         magazines[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"tacgt_main", "hlcweapons_mp5",};
+        requiredAddons[] = {"tacgt_main", "hlcweapons_mp5"};
         author = CSTRING(Author);
         authors[] = {"TyroneMF"};
         url = CSTRING(URL);

--- a/addons/mp7/config.cpp
+++ b/addons/mp7/config.cpp
@@ -9,7 +9,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacgt_main", "CUP_Weapons_MP7"};
         author = CSTRING(Author);
-        authors[] = {"GilleeDoo", "TyroneMF"};
+        authors[] = {"TyroneMF"};
         url = CSTRING(URL);
         VERSION_CONFIG;
     };

--- a/addons/remass/BI.hpp
+++ b/addons/remass/BI.hpp
@@ -22,6 +22,12 @@
     };
 
     // 762x39 AK Magazines
+    class 30Rnd_762x39_Mag_F: CA_Magazine {
+        mass = 11;
+    };
+    class 30Rnd_762x39_AK12_Mag_F: 30Rnd_762x39_Mag_F {
+        mass = 11;
+    };
     class 75Rnd_762x39_Mag_F: 30Rnd_762x39_Mag_F {
         mass = 25;
     };

--- a/addons/remass/CfgMagazines.hpp
+++ b/addons/remass/CfgMagazines.hpp
@@ -1,7 +1,5 @@
 class CfgMagazines {
     class CA_Magazine;
-    class 30Rnd_762x39_Mag_F;
-    class 30Rnd_762x39_AK12_Mag_F;
 
 #include "BI.hpp"
 #include "CUP.hpp"

--- a/addons/rename/CfgMagazines.hpp
+++ b/addons/rename/CfgMagazines.hpp
@@ -54,12 +54,113 @@ class CfgMagazines {
     class 200Rnd_556x45_Box_Tracer_Red_F: 200Rnd_556x45_Box_Tracer_F {
         displayName = "$STR_TACGT_Rename_200Rnd_556x45_Box_Tracer_Red_Display";
     };
-    
-    // 20Rnd 762 Magazines
+
+    // 30Rnd 762x39 Magazines
+    class 30Rnd_762x39_Mag_F: CA_Magazine {
+        displayName = "$STR_TACGT_Rename_30Rnd_762x39_Mag";
+    };
+    class 30Rnd_762x39_Mag_Green_F: 30Rnd_762x39_Mag_F {
+        displayName = "$STR_TACGT_Rename_30Rnd_762x39_Mag_Green";
+    };
+    class 30Rnd_762x39_Mag_Tracer_F: 30Rnd_762x39_Mag_F {
+        displayName = "$STR_TACGT_Rename_30Rnd_762x39_Mag_Yellow_Tracer";
+    };
+    class 30Rnd_762x39_Mag_Tracer_Green_F: 30Rnd_762x39_Mag_Tracer_F {
+        displayName = "$STR_TACGT_Rename_30Rnd_762x39_Mag_Green_Tracer";
+    };
+    class 30Rnd_762x39_AK12_Mag_F: 30Rnd_762x39_Mag_F {
+        displayName = "$STR_TACGT_Rename_30Rnd_762x39_AK12_Mag";
+    };
+    class 30Rnd_762x39_AK12_Mag_Tracer_F: 30Rnd_762x39_AK12_Mag_F {
+        displayName = "$STR_TACGT_Rename_30Rnd_762x39_AK12_Mag_Tracer";
+    };
+    class 30rnd_762x39_AK12_Arid_Mag_F: 30Rnd_762x39_AK12_Mag_F {
+        displayName = "$STR_TACGT_Rename_30Rnd_762x39_AK12_Arid_Mag";
+    };
+    class 30rnd_762x39_AK12_Arid_Mag_Tracer_F: 30Rnd_762x39_AK12_Mag_Tracer_F {
+        displayName = "$STR_TACGT_Rename_30Rnd_762x39_AK12_Arid_Mag_Tracer";
+    };
+    class 30rnd_762x39_AK12_Lush_Mag_F: 30Rnd_762x39_AK12_Mag_F {
+        displayName = "$STR_TACGT_Rename_30Rnd_762x39_AK12_Lush_Mag";
+    };
+    class 30rnd_762x39_AK12_Lush_Mag_Tracer_F: 30Rnd_762x39_AK12_Mag_Tracer_F {
+        displayName = "$STR_TACGT_Rename_30Rnd_762x39_AK12_Lush_Mag_Tracer";
+    };
+    class 75Rnd_762x39_Mag_F: 30Rnd_762x39_Mag_F { // Updating base class?
+        displayName = "$STR_TACGT_Rename_75Rnd_762x39_AKM_Mag";
+    };
+    class 75Rnd_762x39_Mag_Tracer_F: 75Rnd_762x39_Mag_F {
+        displayName = "$STR_TACGT_Rename_75Rnd_762x39_AKM_Mag_Tracer";
+    };
+    class 75rnd_762x39_AK12_Mag_F: 30Rnd_762x39_AK12_Mag_F {
+        displayName = "$STR_TACGT_Rename_75Rnd_762x39_AK12_Mag";
+    };
+    class 75rnd_762x39_AK12_Mag_Tracer_F: 75rnd_762x39_AK12_Mag_F {
+        displayName = "$STR_TACGT_Rename_75Rnd_762x39_AK12_Mag_Tracer";
+    };
+    class 75rnd_762x39_AK12_Arid_Mag_F: 75rnd_762x39_AK12_Mag_F {
+        displayName = "$STR_TACGT_Rename_75Rnd_762x39_AK12_Arid_Mag";
+    };
+    class 75rnd_762x39_AK12_Arid_Mag_Tracer_F: 75rnd_762x39_AK12_Mag_Tracer_F {
+        displayName = "$STR_TACGT_Rename_75Rnd_762x39_AK12_Arid_Mag_Tracer";
+    };
+    class 75rnd_762x39_AK12_Lush_Mag_F: 30Rnd_762x39_AK12_Mag_F {
+        displayName = "$STR_TACGT_Rename_75Rnd_762x39_AK12_Lush_Mag";
+    };
+    class 75rnd_762x39_AK12_Lush_Mag_Tracer_F: 75rnd_762x39_AK12_Mag_Tracer_F {
+        displayName = "$STR_TACGT_Rename_75Rnd_762x39_AK12_Lush_Mag_Tracer";
+    };
+
+    // 20Rnd 762x51 Magazines
     class 20Rnd_762x51_Mag: CA_Magazine {
         displayName = "$STR_TACGT_Rename_20Rnd_762x51_Mag";
     };
     class ACE_20Rnd_762x51_Mag_Tracer: 20Rnd_762x51_Mag {
         displayName = "$STR_TACGT_Rename_20Rnd_762x51_Tracer_Mag";
+    };
+    
+    // 50Rnd 5.7 Magazine
+    class 50Rnd_570x28_SMG_03: CA_Magazine {
+        displayName = "$STR_TACGT_Rename_50Rnd_570x28_Mag";
+    };
+    
+    // 30Rnd 9x19 Magazines
+    class 30Rnd_9x21_Mag: CA_Magazine {
+        displayName = "$STR_TACGT_Rename_30Rnd_9x21_Mag";
+    };
+    class 30Rnd_9x21_Green_Mag: 30Rnd_9x21_Mag {
+        displayName = "$STR_TACGT_Rename_30Rnd_9x21_Green_Mag";
+    };
+    class 30Rnd_9x21_Red_Mag: 30Rnd_9x21_Mag {
+        displayName = "$STR_TACGT_Rename_30Rnd_9x21_Red_Mag";
+    };
+    class 30Rnd_9x21_Yellow_Mag: 30Rnd_9x21_Mag {
+        displayName = "$STR_TACGT_Rename_30Rnd_9x21_Yellow_Mag";
+    };
+    class 30Rnd_9x21_Mag_SMG_02: 30Rnd_9x21_Mag {
+        displayName = "$STR_TACGT_Rename_30Rnd_9x21_Mag";
+    };
+    class 30Rnd_9x21_Mag_SMG_02_Tracer_Green: 30Rnd_9x21_Mag_SMG_02 {
+        displayName = "$STR_TACGT_Rename_30Rnd_9x21_Green_Mag";
+    };
+    class 30Rnd_9x21_Mag_SMG_02_Tracer_Red: 30Rnd_9x21_Mag_SMG_02 {
+        displayName = "$STR_TACGT_Rename_30Rnd_9x21_Red_Mag";
+    };
+    class 30Rnd_9x21_Mag_SMG_02_Tracer_Yellow: 30Rnd_9x21_Mag_SMG_02 {
+        displayName = "$STR_TACGT_Rename_30Rnd_9x21_Yellow_Mag";
+    };
+
+    // 17Rnd 9x19 Magazines
+    class 16Rnd_9x21_Mag: 30Rnd_9x21_Mag {
+        displayName = "$STR_TACGT_Rename_17Rnd_9x21_Mag";
+    };
+    class 16Rnd_9x21_green_Mag: 16Rnd_9x21_Mag {
+        displayName = "$STR_TACGT_Rename_17Rnd_9x21_Green_Mag";
+    };
+    class 16Rnd_9x21_red_Mag: 16Rnd_9x21_Mag {
+        displayName = "$STR_TACGT_Rename_17Rnd_9x21_Red_Mag";
+    };
+    class 16Rnd_9x21_yellow_Mag: 16Rnd_9x21_Mag {
+        displayName = "$STR_TACGT_Rename_17Rnd_9x21_Yellow_Mag";
     };
 };

--- a/addons/rename/CfgMagazines.hpp
+++ b/addons/rename/CfgMagazines.hpp
@@ -86,7 +86,7 @@ class CfgMagazines {
     class 30rnd_762x39_AK12_Lush_Mag_Tracer_F: 30Rnd_762x39_AK12_Mag_Tracer_F {
         displayName = "$STR_TACGT_Rename_30Rnd_762x39_AK12_Lush_Mag_Tracer";
     };
-    class 75Rnd_762x39_Mag_F: 30Rnd_762x39_Mag_F { // Updating base class?
+    class 75Rnd_762x39_Mag_F: 30Rnd_762x39_Mag_F {
         displayName = "$STR_TACGT_Rename_75Rnd_762x39_AKM_Mag";
     };
     class 75Rnd_762x39_Mag_Tracer_F: 75Rnd_762x39_Mag_F {
@@ -104,7 +104,7 @@ class CfgMagazines {
     class 75rnd_762x39_AK12_Arid_Mag_Tracer_F: 75rnd_762x39_AK12_Mag_Tracer_F {
         displayName = "$STR_TACGT_Rename_75Rnd_762x39_AK12_Arid_Mag_Tracer";
     };
-    class 75rnd_762x39_AK12_Lush_Mag_F: 30Rnd_762x39_AK12_Mag_F {
+    class 75rnd_762x39_AK12_Lush_Mag_F: 75rnd_762x39_AK12_Mag_F {
         displayName = "$STR_TACGT_Rename_75Rnd_762x39_AK12_Lush_Mag";
     };
     class 75rnd_762x39_AK12_Lush_Mag_Tracer_F: 75rnd_762x39_AK12_Mag_Tracer_F {

--- a/addons/rename/README.md
+++ b/addons/rename/README.md
@@ -8,6 +8,9 @@
 
 ### **Ammunition Designations:**
 
+##### 9x19
+- Luger: Standard Ball round.
+
 ##### 5.56x45
 - M855: Standard ball round.
 - M856: Tracer round matching the same performance as M855.
@@ -16,6 +19,12 @@
 - M995: Armour Piercing round.
 - MK262: Match-quality round that is more effective at longer ranges than standard M855.
 - MK318: Enhanced variant of the M855, Designed to better penetrate objects with increased consistency.
+
+##### 5.7x28
+- SS190: Standard Ball round.
+
+##### 7.62x39
+- PS: Standard steel-core round.
 
 ##### 7.62x51
 - M80: Standard Ball round.

--- a/addons/rename/stringtable.xml
+++ b/addons/rename/stringtable.xml
@@ -107,7 +107,7 @@
             <English>7.62mm 20Rnd Mag (M80)</English>
         </Key>
         <Key ID="STR_TACGT_Rename_20Rnd_762x51_Tracer_Mag">
-            <English>7.62mm 20Rnd [T] Mag (M62)</English>
+            <English>7.62mm 20Rnd [T] Red Mag (M62)</English>
         </Key>
         <Key ID="STR_TACGT_Rename_50Rnd_570x28_Mag">
             <English>5.7mm 50Rnd Mag (SS190)</English>

--- a/addons/rename/stringtable.xml
+++ b/addons/rename/stringtable.xml
@@ -2,7 +2,7 @@
 <Project name="TACGT">
     <Package name="Rename">
         <Key ID="STR_TACGT_Rename_30Rnd_556x45_Stanag_Display">
-            <English>5.56mm 30Rnd STANAG (M855)</English>
+            <English>5.56mm 30Rnd STANAG [RT] Yellow (M855)</English>
         </Key>
         <Key ID="STR_TACGT_Rename_30Rnd_556x45_Stanag_Green_Display">
             <English>5.56mm 30Rnd STANAG [RT] Green (M855)</English>
@@ -49,11 +49,92 @@
         <Key ID="STR_TACGT_Rename_200Rnd_556x45_Box_Tracer_Red_Display">
             <English>5.56mm 200Rnd [T] Red Box Mag (M856)</English>
         </Key>
+        <Key ID="STR_TACGT_Rename_30Rnd_762x39_Mag">
+            <English>7.62mm 30Rnd [RT] Yellow Mag (PS)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_30Rnd_762x39_Mag_Green">
+            <English>7.62mm 30Rnd [RT] Green Mag (PS)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_30Rnd_762x39_Mag_Yellow_Tracer">
+            <English>7.62mm 30Rnd [T] Yellow Mag (PS)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_30Rnd_762x39_Mag_Green_Tracer">
+            <English>7.62mm 30Rnd [T] Green Mag (PS)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_30Rnd_762x39_AK12_Mag">
+            <English>7.62mm 30Rnd AK-12 [RT] Green Mag (PS)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_30Rnd_762x39_AK12_Mag_Tracer">
+            <English>7.62mm 30Rnd AK-12 [T] Green Mag (PS)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_30Rnd_762x39_AK12_Arid_Mag">
+            <English>7.62mm 30Rnd AK-12 Arid [RT] Green Mag (PS)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_30Rnd_762x39_AK12_Arid_Mag_Tracer">
+            <English>7.62mm 30Rnd AK-12 Arid [T] Green Mag (PS)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_30Rnd_762x39_AK12_Lush_Mag">
+            <English>7.62mm 30Rnd AK-12 Khaki [RT] Green Mag (PS)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_30Rnd_762x39_AK12_Lush_Mag_Tracer">
+            <English>7.62mm 30Rnd AK-12 Khaki [T] Green Mag (PS)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_75Rnd_762x39_AKM_Mag">
+            <English>7.62mm 75Rnd AKM [RT] Yellow Mag (PS)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_75Rnd_762x39_AKM_Mag_Tracer">
+            <English>7.62mm 75Rnd AKM [T] Yellow Mag (PS)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_75Rnd_762x39_AK12_Mag">
+            <English>7.62mm 75Rnd AK-12 [RT] Green Mag (PS)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_75Rnd_762x39_AK12_Mag_Tracer">
+            <English>7.62mm 75Rnd AK-12 [T] Green Mag (PS)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_75Rnd_762x39_AK12_Arid_Mag">
+            <English>7.62mm 75Rnd AK-12 Arid [RT] Green Mag (PS)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_75Rnd_762x39_AK12_Arid_Mag_Tracer">
+            <English>7.62mm 75Rnd AK-12 Arid [T] Green Mag (PS)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_75Rnd_762x39_AK12_Lush_Mag">
+            <English>7.62mm 75Rnd AK-12 Khaki [RT] Green Mag (PS)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_75Rnd_762x39_AK12_Lush_Mag_Tracer">
+            <English>7.62mm 75Rnd AK-12 Khaki [T] Green Mag (PS)</English>
+        </Key>
         <Key ID="STR_TACGT_Rename_20Rnd_762x51_Mag">
             <English>7.62mm 20Rnd Mag (M80)</English>
         </Key>
         <Key ID="STR_TACGT_Rename_20Rnd_762x51_Tracer_Mag">
             <English>7.62mm 20Rnd [T] Mag (M62)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_50Rnd_570x28_Mag">
+            <English>5.7mm 50Rnd Mag (SS190)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_30Rnd_9x21_Mag">
+            <English>9mm 30Rnd Mag (Luger)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_30Rnd_9x21_Green_Mag">
+            <English>9mm 30Rnd [RT] Green Mag (Luger)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_30Rnd_9x21_Red_Mag">
+            <English>9mm 30Rnd [RT] Red Mag (Luger)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_30Rnd_9x21_Yellow_Mag">
+            <English>9mm 30Rnd [RT] Yellow Mag (Luger)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_17Rnd_9x21_Mag">
+            <English>9mm 17Rnd Mag (Luger)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_17Rnd_9x21_Green_Mag">
+            <English>9mm 17Rnd [RT] Green Mag (Luger)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_17Rnd_9x21_Red_Mag">
+            <English>9mm 17Rnd [RT] Red Mag (Luger)</English>
+        </Key>
+        <Key ID="STR_TACGT_Rename_17Rnd_9x21_Yellow_Mag">
+            <English>9mm 17Rnd [RT] Yellow Mag (Luger)</English>
         </Key>
         <Key ID="STR_TACGT_Rename_Hamr_2D_Display">
             <English>Leupold Mark 4 HAMR (2D)</English>

--- a/addons/rename/stringtable.xml
+++ b/addons/rename/stringtable.xml
@@ -20,16 +20,16 @@
             <English>5.56mm 30Rnd STANAG [T] Yellow (M856)</English>
         </Key>
         <Key ID="STR_TACGT_Rename_150Rnd_556x45_Drum_Display">
-            <English>5.56mm 150Rnd Drum Mag (M855)</English>
+            <English>5.56mm 150Rnd [RT] Red Drum Mag (M855)</English>
         </Key>
         <Key ID="STR_TACGT_Rename_150Rnd_556x45_Drum_Sand_Display">
-            <English>5.56mm 150Rnd Sand Drum Mag (M855)</English>
+            <English>5.56mm 150Rnd Sand [RT] Red Drum Mag (M855)</English>
         </Key>
         <Key ID="STR_TACGT_Rename_150Rnd_556x45_Drum_Sand_Tracer_Display">
             <English>5.56mm 150Rnd Sand [T] Red Drum Mag (M856)</English>
         </Key>
         <Key ID="STR_TACGT_Rename_150Rnd_556x45_Drum_Green_Display">
-            <English>5.56mm 150Rnd Green Drum Mag (M855)</English>
+            <English>5.56mm 150Rnd Green [RT] Red Drum Mag (M855)</English>
         </Key>
         <Key ID="STR_TACGT_Rename_150Rnd_556x45_Drum_Green_Tracer_Display">
             <English>5.56mm 150Rnd Green [T] Red Drum Mag (M856)</English>

--- a/addons/saiga12/config.cpp
+++ b/addons/saiga12/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacgt_main", "tacgt_m1014", "CUP_Weapons_Saiga12K"};
         author = CSTRING(Author);
-        authors[] = {"GilleeDoo", "TyroneMF"};
+        authors[] = {"TyroneMF"};
         url = CSTRING(URL);
         VERSION_CONFIG;
     };

--- a/addons/scar/config.cpp
+++ b/addons/scar/config.cpp
@@ -9,7 +9,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacgt_main", "CUP_Weapons_Scar"};
         author = CSTRING(Author);
-        authors[] = {"GilleeDoo", "TyroneMF"};
+        authors[] = {"TyroneMF"};
         url = CSTRING(URL);
         VERSION_CONFIG;
     };

--- a/addons/sg510/CfgSoundSets.hpp
+++ b/addons/sg510/CfgSoundSets.hpp
@@ -1,5 +1,5 @@
 class CfgSoundSets {
-    CLASS(sg510_Shot_SoundSet) {
+    class CLASS(sg510_Shot_SoundSet) {
         soundShaders[] = {"sg510_closeShot_SoundShader", "sg510_midShot_SoundShader", "sg510_distShot_SoundShader", "sg510_Closure_SoundShader"};
         volumeFactor = 0.8;
         volumeCurve = "InverseSquare3Curve";
@@ -13,7 +13,7 @@ class CfgSoundSets {
         doppler = 0;
         loop = 0;
     };
-    CLASS(sg510_tail_SoundSet) {
+    class CLASS(sg510_tail_SoundSet) {
         soundShaders[] = {"sg510_tailDistant_SoundShader", "sg510_tailForest_SoundShader", "sg510_tailHouses_SoundShader", "sg510_tailInterior_SoundShader", "sg510_tailMeadows_SoundShader", "sg510_tailTrees_SoundShader"};
         volumeFactor = 0.7;
         volumeCurve = "InverseSquare2Curve";
@@ -29,7 +29,7 @@ class CfgSoundSets {
         loop = 0;
         soundShadersLimit = 2;
     };
-    CLASS(sg510_silencerShot_SoundSet) {
+    class CLASS(sg510_silencerShot_SoundSet) {
         soundShaders[] = {"sg510_silencerShot_SoundShader", "sg510_Closure_SoundShader"};
         volumeFactor = 0.7;
         volumeCurve = "InverseSquare3Curve";
@@ -41,7 +41,7 @@ class CfgSoundSets {
         loop = 0;
         sound3DProcessingType = "WeaponMediumShot3DProcessingType";
     };
-    CLASS(sg510_silencerTail_SoundSet) {
+    class CLASS(sg510_silencerTail_SoundSet) {
         soundShaders[] = {"sg510_silencerTailTrees_SoundShader", "sg510_silencerTailForest_SoundShader", "sg510_silencerTailMeadows_SoundShader", "sg510_silencerTailHouses_SoundShader", "sg510_silencerTailInterior_SoundShader"};
         volumeFactor = 0.7;
         volumeCurve = "InverseSquare2Curve";

--- a/addons/sg510/config.cpp
+++ b/addons/sg510/config.cpp
@@ -9,7 +9,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tacgt_main", "hlcweapons_sg550", "hlcweapons_stgw57"};
         author = CSTRING(Author);
-        authors[] = {"GilleeDoo", "TyroneMF"};
+        authors[] = {"TyroneMF"};
         url = CSTRING(URL);
         VERSION_CONFIG;
     };


### PR DESCRIPTION
**When merged this pull request will:**
- Overhaul ammunitions.
- Add M855A1 rounds for SPW/HK416 Drum Mags
- Add PMAG/EMAG Variants for M855, M856, M855A1, M955, MK262, MK318 ammo types.
- Add ammunition designations to vanilla magazines, PS, M80, M62, SS190 & Luger.
- Add 7.62x39 magazines to Remass.
