### PR TITLE
Correct Saiga12k Magazine Sizes

### DIFF
--- a/addons/saiga12/CfgMagazines.hpp
+++ b/addons/saiga12/CfgMagazines.hpp
@@ -1,0 +1,17 @@
+class CfgMagazines {
+    class CA_Magazine;
+    // 8Rnd
+    class CUP_8Rnd_B_Saiga12_74Pellets_M: CA_Magazine {
+        count = 8;
+    };
+    class CUP_8Rnd_B_Saiga12_74Slug_M: CA_Magazine {
+        count = 8;
+    };
+    // 20Rnd
+    class CUP_20Rnd_B_Saiga12_74Pellets_M: CUP_8Rnd_B_Saiga12_74Pellets_M {
+        count = 20;
+    };
+    class CUP_20Rnd_B_Saiga12_74Slug_M: CUP_8Rnd_B_Saiga12_74Slug_M {
+        count = 20;
+    };
+};

--- a/addons/saiga12/CfgMagazines.hpp
+++ b/addons/saiga12/CfgMagazines.hpp
@@ -3,15 +3,19 @@ class CfgMagazines {
     // 8Rnd
     class CUP_8Rnd_B_Saiga12_74Pellets_M: CA_Magazine {
         count = 8;
+        displayName = CSTRING(8Rnd_Pellet_Display);
     };
     class CUP_8Rnd_B_Saiga12_74Slug_M: CA_Magazine {
         count = 8;
+        displayName = CSTRING(8Rnd_Slug_Display);
     };
     // 20Rnd
     class CUP_20Rnd_B_Saiga12_74Pellets_M: CUP_8Rnd_B_Saiga12_74Pellets_M {
         count = 20;
+        displayName = CSTRING(20Rnd_Pellet_Display);
     };
     class CUP_20Rnd_B_Saiga12_74Slug_M: CUP_8Rnd_B_Saiga12_74Slug_M {
         count = 20;
+        displayName = CSTRING(20Rnd_Slug_Display);
     };
 };

--- a/addons/saiga12/config.cpp
+++ b/addons/saiga12/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"tacgt_main", "tacgt_m1014", "CUP_Weapons_Saiga12K"};
+        requiredAddons[] = {"tacgt_main", "tacgt_m1014", "CUP_Weapons_Saiga12K", "CUP_Weapons_Ammunition"};
         author = ECSTRING(main,Author);
         authors[] = {"TyroneMF"};
         url = ECSTRING(main,URL);
@@ -18,4 +18,5 @@ class Mode_SemiAuto;
 class Mode_Burst;
 class Mode_FullAuto;
 
+#include "CfgMagazines.hpp"
 #include "CfgWeapons.hpp"

--- a/addons/saiga12/stringtable.xml
+++ b/addons/saiga12/stringtable.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project name="TACGT">
+    <Package name="Saiga12">
+        <Key ID="STR_TACGT_Saiga12_8Rnd_Slug_Display">
+            <English>8Rnd Saiga 12k Slug</English>
+        </Key>
+        <Key ID="STR_TACGT_Saiga12_8Rnd_Pellet_Display">
+            <English>8Rnd Saiga 12k Pellets</English>
+        </Key>
+        <Key ID="STR_TACGT_Saiga12_20Rnd_Slug_Display">
+            <English>20Rnd Saiga 12k Slug</English>
+        </Key>
+        <Key ID="STR_TACGT_Saiga12_20Rnd_Pellet_Display">
+            <English>20Rnd Saiga 12k Pellets</English>
+        </Key>
+    </Package>
+</Project>


### PR DESCRIPTION
- Classnames are 8Rnd and 20Rnd, but are currently set as 5Rnd and 12Rnd both magazines are now upped to match classnames.
- Display names are also changed to match new ammo count.
