### PR TITLE
Add Rebalance Component

### DIFF
--- a/addons/rebalance/$PBOPREFIX$
+++ b/addons/rebalance/$PBOPREFIX$
@@ -1,1 +1,1 @@
-x\tacgt\addons\milgp
+x\tacgt\addons\rebalance

--- a/addons/rebalance/$PBOPREFIX$
+++ b/addons/rebalance/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\tacgt\addons\milgp

--- a/addons/rebalance/CfgVehicles.hpp
+++ b/addons/rebalance/CfgVehicles.hpp
@@ -1,0 +1,9 @@
+class CfgVehicles {
+    class Bag_Base;
+    class fatpack_od: Bag_Base {
+        maximumLoad = 180;
+    };
+    class fatpack_coy: fatpack_od {
+        maximumLoad = 180;
+    };
+};

--- a/addons/rebalance/CfgWeapons.hpp
+++ b/addons/rebalance/CfgWeapons.hpp
@@ -1,0 +1,11 @@
+class CfgWeapons {
+    class ItemCore;
+    class VestItem;
+    class Vest_Camo_Base;
+
+#include "milgp_jpc.hpp"
+#include "milgp_mmac.hpp"
+#include "milgp_marciras.hpp"
+#include "s4_cpc.hpp"
+
+};

--- a/addons/rebalance/CfgWeapons.hpp
+++ b/addons/rebalance/CfgWeapons.hpp
@@ -7,5 +7,5 @@ class CfgWeapons {
 #include "milgp_mmac.hpp"
 #include "milgp_marciras.hpp"
 #include "s4_cpc.hpp"
-
+#include "s4_lbt.hpp"
 };

--- a/addons/rebalance/config.cpp
+++ b/addons/rebalance/config.cpp
@@ -1,0 +1,25 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        magazines[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "tacgt_main",
+            "milgp_vests_cfg",
+            "cpc_Vest_config",
+            "lbtt_Vest_config",
+            "fatpack"
+        };
+        author = ECSTRING(main,Author);
+        authors[] = {"TyroneMF"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgWeapons.hpp"
+#include "CfgVehicles.hpp"

--- a/addons/rebalance/milgp_jpc.hpp
+++ b/addons/rebalance/milgp_jpc.hpp
@@ -12,12 +12,12 @@
                     passThrough = 0.45; \
                 }; \
                 class Abdomen { \
-                    hitpointName="HitAbdomen"; \
+                    hitpointName = "HitAbdomen"; \
                     armor = 15; \
                     passThrough = 0.45; \
                 }; \
                 class Body { \
-                    hitpointName="HitBody"; \
+                    hitpointName = "HitBody"; \
                     armor = 15; \
                     passThrough = 0.45; \
                 }; \

--- a/addons/rebalance/milgp_jpc.hpp
+++ b/addons/rebalance/milgp_jpc.hpp
@@ -1,0 +1,182 @@
+    #define MACRO_HITPROTECTION_JPC \
+        class ItemInfo: VestItem { \
+            class HitpointsProtectionInfo { \
+                class Chest { \
+                    HitpointName = "HitChest"; \
+                    armor = 15; \
+                    passThrough = 0.45; \
+                }; \
+                class Diaphragm { \
+                    HitpointName = "HitDiaphragm"; \
+                    armor = 15; \
+                    passThrough = 0.45; \
+                }; \
+                class Abdomen { \
+                    hitpointName="HitAbdomen"; \
+                    armor = 15; \
+                    passThrough = 0.45; \
+                }; \
+                class Body { \
+                    hitpointName="HitBody"; \
+                    armor = 15; \
+                    passThrough = 0.45; \
+                }; \
+            }; \
+        };
+
+    class milgp_v_jpc_assaulter_rgr: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_assaulter_mc: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_assaulter_cb: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_assaulter_khk: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_assaulter_belt_rgr: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_assaulter_belt_mc: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_assaulter_belt_cb: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_assaulter_belt_khk: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_Grenadier_rgr: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_Grenadier_mc: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_Grenadier_cb: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_Grenadier_khk: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_Grenadier_belt_rgr: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_Grenadier_belt_mc: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_Grenadier_belt_cb: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_Grenadier_belt_khk: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_hgunner_rgr: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_hgunner_mc: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_hgunner_cb: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_hgunner_khk: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_hgunner_belt_rgr: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_hgunner_belt_mc: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_hgunner_belt_cb: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_hgunner_belt_khk: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_Medic_rgr: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_Medic_mc: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_Medic_cb: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_Medic_khk: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_medic_belt_rgr: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_medic_belt_mc: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_medic_belt_cb: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_medic_belt_khk: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_Marksman_rgr: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_Marksman_mc: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_Marksman_cb: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_Marksman_khk: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_marksman_belt_rgr: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_marksman_belt_mc: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_marksman_belt_cb: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_marksman_belt_khk: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_TeamLeader_rgr: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_TeamLeader_mc: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_TeamLeader_cb: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_TeamLeader_khk: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_teamleader_belt_rgr: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_teamleader_belt_mc: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_teamleader_belt_cb: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_teamleader_belt_khk: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_Light_rgr: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_Light_mc: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_Light_cb: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };
+    class milgp_v_jpc_Light_khk: ItemCore {
+        MACRO_HITPROTECTION_JPC
+    };

--- a/addons/rebalance/milgp_marciras.hpp
+++ b/addons/rebalance/milgp_marciras.hpp
@@ -1,0 +1,182 @@
+#define MACRO_HITPROTECTION_MARCIRAS \
+        class ItemInfo: VestItem { \
+            class HitpointsProtectionInfo { \
+                class Chest { \
+                    HitpointName = "HitChest"; \
+                    armor = 18; \
+                    passThrough = 0.3; \
+                }; \
+                class Diaphragm { \
+                    HitpointName = "HitDiaphragm"; \
+                    armor = 18; \
+                    passThrough = 0.3; \
+                }; \
+                class Abdomen { \
+                    hitpointName="HitAbdomen"; \
+                    armor = 18; \
+                    passThrough = 0.3; \
+                }; \
+                class Body { \
+                    hitpointName="HitBody"; \
+                    armor = 18; \
+                    passThrough = 0.3; \
+                }; \
+            }; \
+        };
+
+class milgp_v_marciras_teamleader_mc: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_teamleader_belt_mc: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_assaulter_mc: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_assaulter_belt_mc: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_grenadier_mc: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_grenadier_belt_mc: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_marksman_mc: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_marksman_belt_mc: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_hgunner_mc: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_hgunner_belt_mc: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_medic_mc: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_medic_belt_mc: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_light_mc: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_teamleader_RGR: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_teamleader_belt_RGR: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_assaulter_rgr: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_assaulter_belt_rgr: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_grenadier_rgr: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_grenadier_belt_rgr: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_marksman_rgr: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_marksman_belt_rgr: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_hgunner_rgr: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_hgunner_belt_rgr: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_medic_rgr: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_medic_belt_rgr: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_light_rgr: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_teamleader_CB: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_teamleader_belt_CB: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_assaulter_cb: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_assaulter_belt_cb: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_grenadier_cb: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_grenadier_belt_cb: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_marksman_cb: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_marksman_belt_cb: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_hgunner_cb: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_hgunner_belt_cb: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_medic_cb: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_medic_belt_cb: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_light_cb: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_teamleader_KHK: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_teamleader_belt_KHK: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_assaulter_khk: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_assaulter_belt_khk: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_grenadier_khk: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_grenadier_belt_khk: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_marksman_khk: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_marksman_belt_khk: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_hgunner_khk: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_hgunner_belt_khk: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_medic_khk: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_medic_belt_khk: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};
+class milgp_v_marciras_light_khk: ItemCore {
+    MACRO_HITPROTECTION_MARCIRAS
+};

--- a/addons/rebalance/milgp_marciras.hpp
+++ b/addons/rebalance/milgp_marciras.hpp
@@ -12,12 +12,12 @@
                     passThrough = 0.3; \
                 }; \
                 class Abdomen { \
-                    hitpointName="HitAbdomen"; \
+                    hitpointName = "HitAbdomen"; \
                     armor = 18; \
                     passThrough = 0.3; \
                 }; \
                 class Body { \
-                    hitpointName="HitBody"; \
+                    hitpointName = "HitBody"; \
                     armor = 18; \
                     passThrough = 0.3; \
                 }; \

--- a/addons/rebalance/milgp_mmac.hpp
+++ b/addons/rebalance/milgp_mmac.hpp
@@ -1,0 +1,182 @@
+#define MACRO_HITPROTECTION_MMAC \
+        class ItemInfo: VestItem { \
+            class HitpointsProtectionInfo { \
+                class Chest { \
+                    HitpointName = "HitChest"; \
+                    armor = 16; \
+                    passThrough = 0.4; \
+                }; \
+                class Diaphragm { \
+                    HitpointName = "HitDiaphragm"; \
+                    armor = 16; \
+                    passThrough = 0.4; \
+                }; \
+                class Abdomen { \
+                    hitpointName="HitAbdomen"; \
+                    armor = 16; \
+                    passThrough = 0.4; \
+                }; \
+                class Body { \
+                    hitpointName="HitBody"; \
+                    armor = 16; \
+                    passThrough = 0.4; \
+                }; \
+            }; \
+        };
+
+class milgp_v_mmac_light_rgr: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_assaulter_rgr: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_assaulter_belt_rgr: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_medic_rgr: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_medic_belt_rgr: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_teamleader_rgr: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_teamleader_belt_rgr: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_marksman_rgr: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_marksman_belt_rgr: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_hgunner_rgr: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_hgunner_belt_rgr: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_grenadier_rgr: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_grenadier_belt_rgr: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_light_KHK: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_assaulter_KHK: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_assaulter_belt_KHK: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_medic_KHK: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_medic_belt_KHK: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_teamleader_KHK: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_teamleader_belt_KHK: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_marksman_KHK: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_marksman_belt_KHK: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_hgunner_KHK: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_hgunner_belt_KHK: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_grenadier_KHK: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_grenadier_belt_KHK: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_light_MC: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_assaulter_MC: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_assaulter_belt_MC: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_medic_MC: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_medic_belt_MC: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_teamleader_MC: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_teamleader_belt_MC: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_marksman_MC: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_marksman_belt_MC: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_hgunner_MC: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_hgunner_belt_MC: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_grenadier_MC: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_grenadier_belt_MC: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_light_CB: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_assaulter_CB: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_assaulter_belt_CB: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_medic_CB: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_medic_belt_CB: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_teamleader_CB: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_teamleader_belt_CB: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_marksman_CB: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_marksman_belt_CB: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_hgunner_CB: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_hgunner_belt_CB: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_grenadier_CB: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};
+class milgp_v_mmac_grenadier_belt_CB: ItemCore {
+    MACRO_HITPROTECTION_MMAC
+};

--- a/addons/rebalance/milgp_mmac.hpp
+++ b/addons/rebalance/milgp_mmac.hpp
@@ -12,12 +12,12 @@
                     passThrough = 0.4; \
                 }; \
                 class Abdomen { \
-                    hitpointName="HitAbdomen"; \
+                    hitpointName = "HitAbdomen"; \
                     armor = 16; \
                     passThrough = 0.4; \
                 }; \
                 class Body { \
-                    hitpointName="HitBody"; \
+                    hitpointName = "HitBody"; \
                     armor = 16; \
                     passThrough = 0.4; \
                 }; \

--- a/addons/rebalance/s4_cpc.hpp
+++ b/addons/rebalance/s4_cpc.hpp
@@ -12,12 +12,12 @@
                     passThrough = 0.38; \
                 }; \
                 class Abdomen { \
-                    hitpointName="HitAbdomen"; \
+                    hitpointName = "HitAbdomen"; \
                     armor = 16; \
                     passThrough = 0.38; \
                 }; \
                 class Body { \
-                    hitpointName="HitBody"; \
+                    hitpointName = "HitBody"; \
                     armor = 16; \
                     passThrough = 0.38; \
                 }; \

--- a/addons/rebalance/s4_cpc.hpp
+++ b/addons/rebalance/s4_cpc.hpp
@@ -1,0 +1,97 @@
+#define MACRO_HITPROTECTION_CPC \
+        class ItemInfo: VestItem { \
+            class HitpointsProtectionInfo { \
+                class Chest { \
+                    HitpointName = "HitChest"; \
+                    armor = 16; \
+                    passThrough = 0.38; \
+                }; \
+                class Diaphragm { \
+                    HitpointName = "HitDiaphragm"; \
+                    armor = 16; \
+                    passThrough = 0.38; \
+                }; \
+                class Abdomen { \
+                    hitpointName="HitAbdomen"; \
+                    armor = 16; \
+                    passThrough = 0.38; \
+                }; \
+                class Body { \
+                    hitpointName="HitBody"; \
+                    armor = 16; \
+                    passThrough = 0.38; \
+                }; \
+            }; \
+        };
+
+class cpc_Fast_coy: Vest_Camo_Base {
+    MACRO_HITPROTECTION_CPC
+};
+class cpc_Fast_rngr: cpc_Fast_coy {};
+class cpc_Fast_mc: cpc_Fast_coy {};
+
+class cpc_Fastbelt_coy: Vest_Camo_Base {
+    MACRO_HITPROTECTION_CPC
+};
+class cpc_Fastbelt_rngr: cpc_Fastbelt_coy {};
+class cpc_Fastbelt_mc: cpc_Fastbelt_coy {};
+
+class cpc_weaponsbelt_coy: Vest_Camo_Base {
+    MACRO_HITPROTECTION_CPC
+};
+class cpc_weaponsbelt_mc: cpc_weaponsbelt_coy {};
+class cpc_weaponsbelt_rngr: cpc_weaponsbelt_coy {};
+
+class cpc_light_coy: Vest_Camo_Base {
+    MACRO_HITPROTECTION_CPC
+};
+class cpc_light_rngr: cpc_light_coy {};
+class cpc_light_mc: cpc_light_coy {};
+
+class cpc_lightbelt_coy: Vest_Camo_Base {
+    MACRO_HITPROTECTION_CPC
+};
+class cpc_lightbelt_rngr: cpc_lightbelt_coy {};
+class cpc_lightbelt_mc: cpc_lightbelt_coy {};
+
+class cpc_weapons_coy: Vest_Camo_Base {
+    MACRO_HITPROTECTION_CPC
+};
+class cpc_weapons_rngr: cpc_weapons_coy {};
+class cpc_weapons_mc: cpc_weapons_coy {};
+
+class cpc_communications_coy: Vest_Camo_Base {
+    MACRO_HITPROTECTION_CPC
+};
+class cpc_communications_mc: cpc_communications_coy {};
+class cpc_communications_rngr: cpc_communications_coy {};
+
+class cpc_communicationsbelt_coy: Vest_Camo_Base {
+    MACRO_HITPROTECTION_CPC
+};
+class cpc_communicationsbelt_mc: cpc_communicationsbelt_coy {};
+class cpc_communicationsbelt_rngr: cpc_communicationsbelt_coy {};
+
+class cpc_tl_coy: Vest_Camo_Base {
+    MACRO_HITPROTECTION_CPC
+};
+class cpc_tl_mc: cpc_tl_coy {};
+class cpc_tl_rngr: cpc_tl_coy {};
+
+class cpc_tlbelt_coy: Vest_Camo_Base {
+    MACRO_HITPROTECTION_CPC
+};
+class cpc_tlbelt_rngr: cpc_tlbelt_coy {};
+class cpc_tlbelt_mc: cpc_tlbelt_coy {};
+
+class cpc_medical_coy: Vest_Camo_Base {
+    MACRO_HITPROTECTION_CPC
+};
+class cpc_medical_mc: cpc_tl_coy {};
+class cpc_medical_rngr: cpc_tl_coy {};
+
+class cpc_medicalbelt_coy: Vest_Camo_Base {
+    MACRO_HITPROTECTION_CPC
+};
+class cpc_medicalbelt_rngr: cpc_medicalbelt_coy {};
+class cpc_medicalbelt_mc: cpc_medicalbelt_coy {};

--- a/addons/rebalance/s4_lbt.hpp
+++ b/addons/rebalance/s4_lbt.hpp
@@ -12,12 +12,12 @@
                     passThrough = 0.35; \
                 }; \
                 class Abdomen { \
-                    hitpointName="HitAbdomen"; \
+                    hitpointName = "HitAbdomen"; \
                     armor = 16; \
                     passThrough = 0.35; \
                 }; \
                 class Body { \
-                    hitpointName="HitBody"; \
+                    hitpointName = "HitBody"; \
                     armor = 16; \
                     passThrough = 0.35; \
                 }; \

--- a/addons/rebalance/s4_lbt.hpp
+++ b/addons/rebalance/s4_lbt.hpp
@@ -27,109 +27,53 @@
 class lbt_pouchless_coy: Vest_Camo_Base {
     MACRO_HITPROTECTION_LBT
 };
-class lbt_pouchless_od: lbt_pouchless_coy {
-    MACRO_HITPROTECTION_LBT
-};
-class lbt_pouchless_aor1: lbt_pouchless_coy {
-    MACRO_HITPROTECTION_LBT
-};
-class lbt_pouchless_aor2: lbt_pouchless_coy {
-    MACRO_HITPROTECTION_LBT
-};
-class lbt_pouchless_mc: lbt_pouchless_coy {
-    MACRO_HITPROTECTION_LBT
-};
-class lbt_operator_coy: lbt_pouchless_coy {
-    MACRO_HITPROTECTION_LBT
-};
-class lbt_operator_od: lbt_pouchless_coy {
-    MACRO_HITPROTECTION_LBT
-};
-class lbt_operator_aor1: lbt_pouchless_coy {
-    MACRO_HITPROTECTION_LBT
-};
-class lbt_operator_aor2: lbt_pouchless_coy {
-    MACRO_HITPROTECTION_LBT
-};
-class lbt_operator_mc: lbt_pouchless_coy {
-    MACRO_HITPROTECTION_LBT
-};
+class lbt_pouchless_od: lbt_pouchless_coy {};
+class lbt_pouchless_aor1: lbt_pouchless_coy {};
+class lbt_pouchless_aor2: lbt_pouchless_coy {};
+class lbt_pouchless_mc: lbt_pouchless_coy {};
+class lbt_operator_coy: lbt_pouchless_coy {};
+class lbt_operator_od: lbt_pouchless_coy {};
+class lbt_operator_aor1: lbt_pouchless_coy {};
+class lbt_operator_aor2: lbt_pouchless_coy {};
+class lbt_operator_mc: lbt_pouchless_coy {};
+
 class lbt_weapons_coy: lbt_pouchless_coy {
     MACRO_HITPROTECTION_LBT
 };
-class lbt_weapons_od: lbt_weapons_coy {
-    MACRO_HITPROTECTION_LBT
-};
-class lbt_weapons_aor1: lbt_weapons_coy {
-    MACRO_HITPROTECTION_LBT
-};
-class lbt_weapons_aor2: lbt_weapons_coy {
-    MACRO_HITPROTECTION_LBT
-};
-class lbt_weapons_mc: lbt_pouchless_coy {
-    MACRO_HITPROTECTION_LBT
-};
+class lbt_weapons_od: lbt_weapons_coy {};
+class lbt_weapons_aor1: lbt_weapons_coy {};
+class lbt_weapons_aor2: lbt_weapons_coy {};
+class lbt_weapons_mc: lbt_pouchless_coy {};
+
 class lbt_medical_coy: lbt_pouchless_coy {
     MACRO_HITPROTECTION_LBT
 };
-class lbt_medical_od: lbt_medical_coy {
-    MACRO_HITPROTECTION_LBT
-};
-class lbt_medical_aor1: lbt_medical_coy {
-    MACRO_HITPROTECTION_LBT
-};
-class lbt_medical_aor2: lbt_medical_coy {
-    MACRO_HITPROTECTION_LBT
-};
+class lbt_medical_od: lbt_medical_coy {};
+class lbt_medical_aor1: lbt_medical_coy {};
+class lbt_medical_aor2: lbt_medical_coy {};
+
 class lbt_medical_mc: lbt_pouchless_coy {
     MACRO_HITPROTECTION_LBT
 };
-class lbt_comms_coy: lbt_pouchless_coy {
-    MACRO_HITPROTECTION_LBT
-};
-class lbt_comms_od: lbt_comms_coy {
-    MACRO_HITPROTECTION_LBT
-};
-class lbt_comms_aor1: lbt_comms_coy {
-    MACRO_HITPROTECTION_LBT
-};
-class lbt_comms_aor2: lbt_comms_coy {
-    MACRO_HITPROTECTION_LBT
-};
-class lbt_comms_mc: lbt_pouchless_coy {
-    MACRO_HITPROTECTION_LBT
-};
-class lbt_light_od: lbt_pouchless_coy {
-    MACRO_HITPROTECTION_LBT
-};
-class lbt_light_mc: lbt_pouchless_coy {
-    MACRO_HITPROTECTION_LBT
-};
-class lbt_light_aor1: lbt_pouchless_coy {
-    MACRO_HITPROTECTION_LBT
-};
-class lbt_light_aor2: lbt_pouchless_coy {
-    MACRO_HITPROTECTION_LBT
-};
-class lbt_light_coy: lbt_pouchless_coy {
-    MACRO_HITPROTECTION_LBT
-};
-class lbt_fast_coy: lbt_pouchless_coy {
-    MACRO_HITPROTECTION_LBT
-};
+
+class lbt_comms_coy: lbt_pouchless_coy {};
+class lbt_comms_od: lbt_comms_coy {};
+class lbt_comms_aor1: lbt_comms_coy {};
+class lbt_comms_aor2: lbt_comms_coy {};
+
+class lbt_comms_mc: lbt_pouchless_coy {};
+class lbt_light_od: lbt_pouchless_coy {};
+class lbt_light_mc: lbt_pouchless_coy {};
+class lbt_light_aor1: lbt_pouchless_coy {};
+class lbt_light_aor2: lbt_pouchless_coy {};
+class lbt_light_coy: lbt_pouchless_coy {};
+class lbt_fast_coy: lbt_pouchless_coy {};
+
 class lbt_tl_mc: Vest_Camo_Base {
     MACRO_HITPROTECTION_LBT
 };
-class lbt_tl_coy: lbt_tl_mc {
-    MACRO_HITPROTECTION_LBT
-};
-class lbt_tl_od: lbt_tl_mc {
-    MACRO_HITPROTECTION_LBT
-};
-class lbt_tl_aor1: lbt_tl_mc {
-    MACRO_HITPROTECTION_LBT
-};
-class lbt_tl_aor2: lbt_tl_mc {
-    MACRO_HITPROTECTION_LBT
-};
+class lbt_tl_coy: lbt_tl_mc {};
+class lbt_tl_od: lbt_tl_mc {};
+class lbt_tl_aor1: lbt_tl_mc {};
+class lbt_tl_aor2: lbt_tl_mc {};
 

--- a/addons/rebalance/s4_lbt.hpp
+++ b/addons/rebalance/s4_lbt.hpp
@@ -1,0 +1,135 @@
+#define MACRO_HITPROTECTION_LBT \
+        class ItemInfo: VestItem { \
+            class HitpointsProtectionInfo { \
+                class Chest { \
+                    HitpointName = "HitChest"; \
+                    armor = 16; \
+                    passThrough = 0.35; \
+                }; \
+                class Diaphragm { \
+                    HitpointName = "HitDiaphragm"; \
+                    armor = 16; \
+                    passThrough = 0.35; \
+                }; \
+                class Abdomen { \
+                    hitpointName="HitAbdomen"; \
+                    armor = 16; \
+                    passThrough = 0.35; \
+                }; \
+                class Body { \
+                    hitpointName="HitBody"; \
+                    armor = 16; \
+                    passThrough = 0.35; \
+                }; \
+            }; \
+        };
+
+class lbt_pouchless_coy: Vest_Camo_Base {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_pouchless_od: lbt_pouchless_coy {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_pouchless_aor1: lbt_pouchless_coy {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_pouchless_aor2: lbt_pouchless_coy {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_pouchless_mc: lbt_pouchless_coy {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_operator_coy: lbt_pouchless_coy {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_operator_od: lbt_pouchless_coy {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_operator_aor1: lbt_pouchless_coy {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_operator_aor2: lbt_pouchless_coy {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_operator_mc: lbt_pouchless_coy {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_weapons_coy: lbt_pouchless_coy {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_weapons_od: lbt_weapons_coy {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_weapons_aor1: lbt_weapons_coy {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_weapons_aor2: lbt_weapons_coy {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_weapons_mc: lbt_pouchless_coy {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_medical_coy: lbt_pouchless_coy {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_medical_od: lbt_medical_coy {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_medical_aor1: lbt_medical_coy {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_medical_aor2: lbt_medical_coy {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_medical_mc: lbt_pouchless_coy {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_comms_coy: lbt_pouchless_coy {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_comms_od: lbt_comms_coy {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_comms_aor1: lbt_comms_coy {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_comms_aor2: lbt_comms_coy {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_comms_mc: lbt_pouchless_coy {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_light_od: lbt_pouchless_coy {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_light_mc: lbt_pouchless_coy {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_light_aor1: lbt_pouchless_coy {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_light_aor2: lbt_pouchless_coy {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_light_coy: lbt_pouchless_coy {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_fast_coy: lbt_pouchless_coy {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_tl_mc: Vest_Camo_Base {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_tl_coy: lbt_tl_mc {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_tl_od: lbt_tl_mc {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_tl_aor1: lbt_tl_mc {
+    MACRO_HITPROTECTION_LBT
+};
+class lbt_tl_aor2: lbt_tl_mc {
+    MACRO_HITPROTECTION_LBT
+};
+

--- a/addons/rebalance/script_component.hpp
+++ b/addons/rebalance/script_component.hpp
@@ -1,0 +1,4 @@
+#define COMPONENT rebalance
+#define COMPONENT_BEAUTIFIED Rebalance
+#include "\x\tacgt\addons\main\script_mod.hpp"
+#include "\x\tacgt\addons\main\script_macros.hpp"


### PR DESCRIPTION
Balances vest armour values to match Vanilla counterparts.

- Rebalanced MarCiras/MMAC/JPC vests from Milgp
- Rebalanced S4/LBT vests from Spec4Gear
- Fixed abnormally high load of the Fatpack backpacks (matching Assault Packs)

