### PR TITLE
Update Flare Module to utilise CUP flares

### DIFF
--- a/addons/flares/$PBOPREFIX$
+++ b/addons/flares/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\tacgt\addons\flares

--- a/addons/flares/CfgAmmo.hpp
+++ b/addons/flares/CfgAmmo.hpp
@@ -1,0 +1,14 @@
+class CfgAmmo {
+    class CUP_F_40mm_Star_White;
+    class CUP_F_40mm_StarCluster_White: CUP_F_40mm_Star_White {
+        timeToLive = 60;
+    };
+
+    class CUP_F_40mm_StarCluster_Red: CUP_F_40mm_Star_White {
+        timeToLive = 60;
+    };
+
+    class CUP_F_40mm_StarCluster_Green: CUP_F_40mm_Star_White {
+        timeToLive = 60;
+    };
+};

--- a/addons/flares/CfgVehicles.hpp
+++ b/addons/flares/CfgVehicles.hpp
@@ -1,0 +1,110 @@
+class CfgVehicles {
+    class ModuleFlareRed_F;
+    class ModuleFlareGreen_F;
+    class ModuleFlareWhite_F;
+    class Logic;
+    class Module_F: Logic {
+        class ModuleDescription {
+            class AnyPlayer;
+        };
+    };
+
+    class ModuleFlare_F: Module_F {
+        class Arguments {
+            class Type {
+                displayName="$STR_A3_CfgVehicles_ModuleSmoke_F_Arguments_Color_0";
+                description="$STR_A3_CfgVehicles_ModuleSmoke_F_Arguments_Color_1";
+                class values {
+                    class White {
+                        name="$STR_A3_CfgMagazines_UGL_FlareWhite_F_dns";
+                        value="F_40mm_White";
+                        default=1;
+                    };
+                    class Yellow {
+                        name="$STR_A3_CfgMagazines_UGL_FlareYellow_F_dns";
+                        value="F_40mm_Yellow";
+                    };
+                    class Green {
+                        name="$STR_A3_CfgMagazines_UGL_FlareGreen_F_dns";
+                        value="F_40mm_Green";
+                    };
+                    class Red {
+                        name="$STR_A3_CfgMagazines_UGL_FlareRed_F_dns";
+                        value="F_40mm_Red";
+                    };
+                    class CLASS(Star_Red) {
+                        name = CSTRING(Star_Red_Name);
+                        value = "CUP_F_40mm_Star_Red";
+                    };
+                    class CLASS(Star_White) {
+                        name = CSTRING(Star_White_Name);
+                        value = "CUP_F_40mm_Star_White";
+                    };
+                    class CLASS(Star_Green) {
+                        name = CSTRING(Star_Green_Name);
+                        value = "CUP_F_40mm_Star_Green";
+                    };
+                    class CLASS(Cluster_Red) {
+                        name = CSTRING(Cluster_Red_Name);
+                        value = "CUP_Sub_F_40mm_StarCluster_Red";
+                    };
+                    class CLASS(Cluster_White) {
+                        name = CSTRING(Cluster_White_Name);
+                        value = "CUP_Sub_F_40mm_StarCluster_White";
+                    };
+                    class CLASS(Cluster_Green) {
+                        name = CSTRING(Cluster_Green_Name);
+                        value = "CUP_Sub_F_40mm_StarCluster_Green";
+                    };
+                };
+            };
+        };
+    };
+
+    class CLASS(ModuleFlareStarRed): ModuleFlareRed_F {
+        author = "TyroneMF";
+        scope = 1;
+        scopeCurator = 2;
+        displayName = CSTRING(Star_Red_Name);
+        ammo = "CUP_F_40mm_Star_Red";
+    };
+    class CLASS(ModuleFlareStarWhite): ModuleFlareWhite_F {
+        author = "TyroneMF";
+        scope = 1;
+        scopeCurator = 2;
+        displayName = CSTRING(Star_White_Name);
+        ammo = "CUP_F_40mm_Star_White";
+    };
+
+    class CLASS(ModuleFlareStarGreen): ModuleFlareGreen_F {
+        author = "TyroneMF";
+        scope = 1;
+        scopeCurator = 2;
+        displayName = CSTRING(Star_Green_Name);
+        ammo = "CUP_F_40mm_Star_Green";
+    };
+
+    class CLASS(ModuleFlareClusterRed): ModuleFlareRed_F {
+        author = "TyroneMF";
+        scope = 1;
+        scopeCurator = 2;
+        displayName = CSTRING(Cluster_Red_Name);
+        ammo = "CUP_Sub_F_40mm_StarCluster_Red";
+    };
+
+    class CLASS(ModuleFlareClusterWhite): ModuleFlareWhite_F {
+        author = "TyroneMF";
+        scope = 1;
+        scopeCurator = 2;
+        displayName = CSTRING(Cluster_White_Name);
+        ammo = "CUP_Sub_F_40mm_StarCluster_White";
+    };
+
+    class CLASS(ModuleFlareClusterGreen): ModuleFlareGreen_F {
+        author = "TyroneMF";
+        scope = 1;
+        scopeCurator = 2;
+        displayName = CSTRING(Cluster_Green_Name);
+        ammo = "CUP_Sub_F_40mm_StarCluster_Green";
+    };
+};

--- a/addons/flares/config.cpp
+++ b/addons/flares/config.cpp
@@ -1,0 +1,25 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {
+            QCLASS(ModuleFlareStarRed),
+            QCLASS(ModuleFlareStarWhite),
+            QCLASS(ModuleFlareStarGreen),
+            QCLASS(ModuleFlareClusterRed),
+            QCLASS(ModuleFlareClusterWhite),
+            QCLASS(ModuleFlareClusterGreen)
+        };
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"tacgt_main", "CUP_Weapons_Ammunition"};
+        author = ECSTRING(main,Author);
+        authors[] = {"TyroneMF"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgAmmo.hpp"
+#include "CfgVehicles.hpp"

--- a/addons/flares/script_component.hpp
+++ b/addons/flares/script_component.hpp
@@ -1,0 +1,4 @@
+#define COMPONENT flares
+#define COMPONENT_BEAUTIFIED Flares
+#include "\x\tacgt\addons\main\script_mod.hpp"
+#include "\x\tacgt\addons\main\script_macros.hpp"

--- a/addons/flares/stringtable.xml
+++ b/addons/flares/stringtable.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project name="TACGT">
+    <Package name="Flares">
+        <Key ID="STR_TACGT_Flares_Star_Red_Name">
+            <English>Parachute Red</English>
+        </Key>
+        <Key ID="STR_TACGT_Flares_Star_White_Name">
+            <English>Parachute White</English>
+        </Key>
+        <Key ID="STR_TACGT_Flares_Star_Green_Name">
+            <English>Parachute Green</English>
+        </Key>
+        <Key ID="STR_TACGT_Flares_Cluster_Red_Name">
+            <English>Cluster Red</English>
+        </Key>
+        <Key ID="STR_TACGT_Flares_Cluster_White_Name">
+            <English>Cluster White</English>
+        </Key>
+        <Key ID="STR_TACGT_Flares_Cluster_Green_Name">
+            <English>Cluster Green</English>
+        </Key>
+    </Package>
+</Project>


### PR DESCRIPTION
- Updates Editor & Zeus module list to include Parachute and Cluster flares in Red/White/Green
- Increased lifetime of cluster flares from 7s > ~60s

Requested by @jonpas 