### PR TITLE
Flashlight - Fix LLM MKIII & Add switch state names

### DIFF
--- a/addons/flashlight/ANPEQ_Black.hpp
+++ b/addons/flashlight/ANPEQ_Black.hpp
@@ -12,6 +12,7 @@ class CLASS(ANPEQ_15_Laser_Black): cup_acc_anpeq_15_flashlight_black_l {
     };
     MRT_SwitchItemNextClass = QCLASS(ANPEQ_15_Light_Black);
     MRT_SwitchItemPrevClass = QCLASS(ANPEQ_15_Vis_Laser_Black);
+    MRT_SwitchItemHintText = CSTRING(Laser_Pointer);
 };
 
 class cup_acc_anpeq_15_flashlight_black_f;
@@ -28,6 +29,7 @@ class CLASS(ANPEQ_15_Light_Black): cup_acc_anpeq_15_flashlight_black_f {
     };
     MRT_SwitchItemNextClass = QCLASS(ANPEQ_15_Low_Light_Black);
     MRT_SwitchItemPrevClass = QCLASS(ANPEQ_15_Laser_Black);
+    MRT_SwitchItemHintText = CSTRING(High_Power_Light);
 };
 
 class CLASS(ANPEQ_15_Low_Light_Black): cup_acc_anpeq_15_flashlight_black_f {
@@ -43,6 +45,7 @@ class CLASS(ANPEQ_15_Low_Light_Black): cup_acc_anpeq_15_flashlight_black_f {
     };
     MRT_SwitchItemNextClass = QCLASS(ANPEQ_15_Vis_Laser_Black);
     MRT_SwitchItemPrevClass = QCLASS(ANPEQ_15_Light_Black);
+    MRT_SwitchItemHintText = CSTRING(Low_Power_Light);
 };
 
 class cup_acc_anpeq_15_flashlight_black_v;
@@ -59,4 +62,6 @@ class CLASS(ANPEQ_15_Vis_Laser_Black): cup_acc_anpeq_15_flashlight_black_v {
     };
     MRT_SwitchItemNextClass = QCLASS(ANPEQ_15_Laser_Black);
     MRT_SwitchItemPrevClass = QCLASS(ANPEQ_15_Low_Light_Black);
+    MRT_SwitchItemHintText = CSTRING(Visible_Laser);
+    ACE_LaserPointer = 1;
 };

--- a/addons/flashlight/ANPEQ_OD.hpp
+++ b/addons/flashlight/ANPEQ_OD.hpp
@@ -12,6 +12,7 @@ class CLASS(ANPEQ_15_Laser_OD): cup_acc_anpeq_15_flashlight_od_l {
     };
     MRT_SwitchItemNextClass = QCLASS(ANPEQ_15_Light_OD);
     MRT_SwitchItemPrevClass = QCLASS(ANPEQ_15_Vis_Laser_OD);
+    MRT_SwitchItemHintText = CSTRING(Laser_Pointer);
 };
 
 class cup_acc_anpeq_15_flashlight_od_f;
@@ -28,6 +29,7 @@ class CLASS(ANPEQ_15_Light_OD): cup_acc_anpeq_15_flashlight_od_f {
     };
     MRT_SwitchItemNextClass = QCLASS(ANPEQ_15_Low_Light_OD);
     MRT_SwitchItemPrevClass = QCLASS(ANPEQ_15_Laser_OD);
+    MRT_SwitchItemHintText = CSTRING(High_Power_Light);
 };
 
 class CLASS(ANPEQ_15_Low_Light_OD): cup_acc_anpeq_15_flashlight_od_f {
@@ -43,6 +45,7 @@ class CLASS(ANPEQ_15_Low_Light_OD): cup_acc_anpeq_15_flashlight_od_f {
     };
     MRT_SwitchItemNextClass = QCLASS(ANPEQ_15_Vis_Laser_OD);
     MRT_SwitchItemPrevClass = QCLASS(ANPEQ_15_Light_OD);
+    MRT_SwitchItemHintText = CSTRING(Low_Power_Light);
 };
 
 class cup_acc_anpeq_15_flashlight_od_v;
@@ -59,4 +62,6 @@ class CLASS(ANPEQ_15_Vis_Laser_OD): cup_acc_anpeq_15_flashlight_od_v {
     };
     MRT_SwitchItemNextClass = QCLASS(ANPEQ_15_Laser_OD);
     MRT_SwitchItemPrevClass = QCLASS(ANPEQ_15_Low_Light_OD);
+    MRT_SwitchItemHintText = CSTRING(Visible_Laser);
+    ACE_LaserPointer = 1;
 };

--- a/addons/flashlight/ANPEQ_Tan.hpp
+++ b/addons/flashlight/ANPEQ_Tan.hpp
@@ -12,6 +12,7 @@ class CLASS(ANPEQ_15_Laser_Tan): cup_acc_anpeq_15_flashlight_tan_l {
     };
     MRT_SwitchItemNextClass = QCLASS(ANPEQ_15_Light_Tan);
     MRT_SwitchItemPrevClass = QCLASS(ANPEQ_15_Vis_Laser_Tan);
+    MRT_SwitchItemHintText = CSTRING(Laser_Pointer);
 };
 
 class cup_acc_anpeq_15_flashlight_tan_f;
@@ -28,6 +29,7 @@ class CLASS(ANPEQ_15_Light_Tan): cup_acc_anpeq_15_flashlight_tan_f {
     };
     MRT_SwitchItemNextClass = QCLASS(ANPEQ_15_Low_Light_Tan);
     MRT_SwitchItemPrevClass = QCLASS(ANPEQ_15_Laser_Tan);
+    MRT_SwitchItemHintText = CSTRING(High_Power_Light);
 };
 
 class CLASS(ANPEQ_15_Low_Light_Tan): cup_acc_anpeq_15_flashlight_tan_f {
@@ -43,6 +45,7 @@ class CLASS(ANPEQ_15_Low_Light_Tan): cup_acc_anpeq_15_flashlight_tan_f {
     };
     MRT_SwitchItemNextClass = QCLASS(ANPEQ_15_Vis_Laser_Tan);
     MRT_SwitchItemPrevClass = QCLASS(ANPEQ_15_Light_Tan);
+    MRT_SwitchItemHintText = CSTRING(Low_Power_Light);
 };
 
 class cup_acc_anpeq_15_flashlight_tan_v;
@@ -59,4 +62,6 @@ class CLASS(ANPEQ_15_Vis_Laser_Tan): cup_acc_anpeq_15_flashlight_tan_v {
     };
     MRT_SwitchItemNextClass = QCLASS(ANPEQ_15_Laser_Tan);
     MRT_SwitchItemPrevClass = QCLASS(ANPEQ_15_Low_Light_Tan);
+    MRT_SwitchItemHintText = CSTRING(Visible_Laser);
+    ACE_LaserPointer = 1;
 };

--- a/addons/flashlight/ANPEQ_Top_Black.hpp
+++ b/addons/flashlight/ANPEQ_Top_Black.hpp
@@ -12,6 +12,7 @@ class CLASS(ANPEQ_15_Top_Laser_Black): cup_acc_anpeq_15_top_flashlight_black_l {
     };
     MRT_SwitchItemNextClass = QCLASS(ANPEQ_15_Top_Light_Black);
     MRT_SwitchItemPrevClass = QCLASS(ANPEQ_15_Top_Vis_Laser_Black);
+    MRT_SwitchItemHintText = CSTRING(Laser_Pointer);
 };
 
 class cup_acc_anpeq_15_top_flashlight_black_f;
@@ -28,6 +29,7 @@ class CLASS(ANPEQ_15_Top_Light_Black): cup_acc_anpeq_15_top_flashlight_black_f {
     };
     MRT_SwitchItemNextClass = QCLASS(ANPEQ_15_Top_Low_Light_Black);
     MRT_SwitchItemPrevClass = QCLASS(ANPEQ_15_Top_Laser_Black);
+    MRT_SwitchItemHintText = CSTRING(High_Power_Light);
 };
 
 class CLASS(ANPEQ_15_Top_Low_Light_Black): cup_acc_anpeq_15_top_flashlight_black_f {
@@ -43,6 +45,7 @@ class CLASS(ANPEQ_15_Top_Low_Light_Black): cup_acc_anpeq_15_top_flashlight_black
     };
     MRT_SwitchItemNextClass = QCLASS(ANPEQ_15_Top_Vis_Laser_Black);
     MRT_SwitchItemPrevClass = QCLASS(ANPEQ_15_Top_Light_Black);
+    MRT_SwitchItemHintText = CSTRING(Low_Power_Light);
 };
 
 class cup_acc_anpeq_15_top_flashlight_black_v;
@@ -59,4 +62,6 @@ class CLASS(ANPEQ_15_Top_Vis_Laser_Black): cup_acc_anpeq_15_top_flashlight_black
     };
     MRT_SwitchItemNextClass = QCLASS(ANPEQ_15_Top_Laser_Black);
     MRT_SwitchItemPrevClass = QCLASS(ANPEQ_15_Top_Low_Light_Black);
+    MRT_SwitchItemHintText = CSTRING(Visible_Laser);
+    ACE_LaserPointer = 1;
 };

--- a/addons/flashlight/ANPEQ_Top_OD.hpp
+++ b/addons/flashlight/ANPEQ_Top_OD.hpp
@@ -12,6 +12,7 @@ class CLASS(ANPEQ_15_Top_Laser_OD): cup_acc_anpeq_15_top_flashlight_od_l {
     };
     MRT_SwitchItemNextClass = QCLASS(ANPEQ_15_Top_Light_OD);
     MRT_SwitchItemPrevClass = QCLASS(ANPEQ_15_Top_Vis_Laser_OD);
+    MRT_SwitchItemHintText = CSTRING(Laser_Pointer);
 };
 
 class cup_acc_anpeq_15_top_flashlight_od_f;
@@ -28,6 +29,7 @@ class CLASS(ANPEQ_15_Top_Light_OD): cup_acc_anpeq_15_top_flashlight_od_f {
     };
     MRT_SwitchItemNextClass = QCLASS(ANPEQ_15_Top_Low_Light_OD);
     MRT_SwitchItemPrevClass = QCLASS(ANPEQ_15_Top_Laser_OD);
+    MRT_SwitchItemHintText = CSTRING(High_Power_Light);
 };
 
 class CLASS(ANPEQ_15_Top_Low_Light_OD): cup_acc_anpeq_15_top_flashlight_od_f {
@@ -43,6 +45,7 @@ class CLASS(ANPEQ_15_Top_Low_Light_OD): cup_acc_anpeq_15_top_flashlight_od_f {
     };
     MRT_SwitchItemNextClass = QCLASS(ANPEQ_15_Top_Vis_Laser_OD);
     MRT_SwitchItemPrevClass = QCLASS(ANPEQ_15_Top_Light_OD);
+    MRT_SwitchItemHintText = CSTRING(Low_Power_Light);
 };
 
 class cup_acc_anpeq_15_top_flashlight_od_v;
@@ -59,4 +62,6 @@ class CLASS(ANPEQ_15_Top_Vis_Laser_OD): cup_acc_anpeq_15_top_flashlight_od_v {
     };
     MRT_SwitchItemNextClass = QCLASS(ANPEQ_15_Top_Laser_OD);
     MRT_SwitchItemPrevClass = QCLASS(ANPEQ_15_Top_Low_Light_OD);
+    MRT_SwitchItemHintText = CSTRING(Visible_Laser);
+    ACE_LaserPointer = 1;
 };

--- a/addons/flashlight/ANPEQ_Top_Tan.hpp
+++ b/addons/flashlight/ANPEQ_Top_Tan.hpp
@@ -12,6 +12,7 @@ class CLASS(ANPEQ_15_Top_Laser_Tan): cup_acc_anpeq_15_top_flashlight_tan_l {
     };
     MRT_SwitchItemNextClass = QCLASS(ANPEQ_15_Top_Light_Tan);
     MRT_SwitchItemPrevClass = QCLASS(ANPEQ_15_Top_Vis_Laser_Tan);
+    MRT_SwitchItemHintText = CSTRING(Laser_Pointer);
 };
 
 class cup_acc_anpeq_15_top_flashlight_tan_f;
@@ -28,6 +29,7 @@ class CLASS(ANPEQ_15_Top_Light_Tan): cup_acc_anpeq_15_top_flashlight_tan_f {
     };
     MRT_SwitchItemNextClass = QCLASS(ANPEQ_15_Top_Low_Light_Tan);
     MRT_SwitchItemPrevClass = QCLASS(ANPEQ_15_Top_Laser_Tan);
+    MRT_SwitchItemHintText = CSTRING(High_Power_Light);
 };
 
 class CLASS(ANPEQ_15_Top_Low_Light_Tan): cup_acc_anpeq_15_top_flashlight_tan_f {
@@ -42,6 +44,7 @@ class CLASS(ANPEQ_15_Top_Low_Light_Tan): cup_acc_anpeq_15_top_flashlight_tan_f {
     };
     MRT_SwitchItemNextClass = QCLASS(ANPEQ_15_Top_Vis_Laser_Tan);
     MRT_SwitchItemPrevClass = QCLASS(ANPEQ_15_Top_Light_Tan);
+    MRT_SwitchItemHintText = CSTRING(Low_Power_Light);
 };
 
 class cup_acc_anpeq_15_top_flashlight_tan_v;
@@ -58,4 +61,6 @@ class CLASS(ANPEQ_15_Top_Vis_Laser_Tan): cup_acc_anpeq_15_top_flashlight_tan_v {
     };
     MRT_SwitchItemNextClass = QCLASS(ANPEQ_15_Top_Laser_Tan);
     MRT_SwitchItemPrevClass = QCLASS(ANPEQ_15_Top_Low_Light_Tan);
+    MRT_SwitchItemHintText = CSTRING(Visible_Laser);
+    ACE_LaserPointer = 1;
 };

--- a/addons/flashlight/LLM.hpp
+++ b/addons/flashlight/LLM.hpp
@@ -13,6 +13,7 @@ class CLASS(LLM01_Laser_Black): CUP_acc_LLM01_L {
     };
     MRT_SwitchItemNextClass = QCLASS(LLM01_Light_Black);
     MRT_SwitchItemPrevClass = QCLASS(LLM01_Vis_Laser_Black);
+    MRT_SwitchItemHintText = CSTRING(Laser_Pointer);
 };
 
 class CUP_acc_LLM01_F;
@@ -29,6 +30,7 @@ class CLASS(LLM01_Light_Black): CUP_acc_LLM01_F {
     };
     MRT_SwitchItemNextClass = QCLASS(LLM01_Low_Light_Black);
     MRT_SwitchItemPrevClass = QCLASS(LLM01_Laser_Black);
+    MRT_SwitchItemHintText = CSTRING(High_Power_Light);
 };
 
 class CLASS(LLM01_Low_Light_Black): CUP_acc_LLM01_F {
@@ -44,6 +46,7 @@ class CLASS(LLM01_Low_Light_Black): CUP_acc_LLM01_F {
     };
     MRT_SwitchItemNextClass = QCLASS(LLM01_Vis_Laser_Black);
     MRT_SwitchItemPrevClass = QCLASS(LLM01_Light_Black);
+    MRT_SwitchItemHintText = CSTRING(Low_Power_Light);
 };
 
 class CLASS(LLM01_Vis_Laser_Black): CUP_acc_LLM01_L {
@@ -58,6 +61,8 @@ class CLASS(LLM01_Vis_Laser_Black): CUP_acc_LLM01_L {
     };
     MRT_SwitchItemNextClass = QCLASS(LLM01_Laser_Black);
     MRT_SwitchItemPrevClass = QCLASS(LLM01_Low_Light_Black);
+    MRT_SwitchItemHintText = CSTRING(Visible_Laser);
+    ACE_LaserPointer = 1;
 };
 
 // Black Variant - LLM MKIII
@@ -75,6 +80,7 @@ class CLASS(LLM_Laser_Black): cup_acc_llm_black {
     };
     MRT_SwitchItemNextClass = QCLASS(LLM_Light_Black);
     MRT_SwitchItemPrevClass = QCLASS(LLM_Vis_Laser_Black);
+    MRT_SwitchItemHintText = CSTRING(Laser_Pointer);
 };
 
 class CUP_acc_LLM_black_Flashlight;
@@ -91,6 +97,7 @@ class CLASS(LLM_Light_Black): CUP_acc_LLM_black_Flashlight {
     };
     MRT_SwitchItemNextClass = QCLASS(LLM_Low_Light_Black);
     MRT_SwitchItemPrevClass = QCLASS(LLM_Laser_Black);
+    MRT_SwitchItemHintText = CSTRING(High_Power_Light);
 };
 
 class CLASS(LLM_Low_Light_Black): CUP_acc_LLM_black_Flashlight {
@@ -106,6 +113,7 @@ class CLASS(LLM_Low_Light_Black): CUP_acc_LLM_black_Flashlight {
     };
     MRT_SwitchItemNextClass = QCLASS(LLM_Vis_Laser_Black);
     MRT_SwitchItemPrevClass = QCLASS(LLM_Light_Black);
+    MRT_SwitchItemHintText = CSTRING(Low_Power_Light);
 };
 
 class CLASS(LLM_Vis_Laser_Black): cup_acc_llm_black {
@@ -116,10 +124,12 @@ class CLASS(LLM_Vis_Laser_Black): cup_acc_llm_black {
         mass = 4;
         class Pointer {};
         class Flashlight {
-            MACRO_LOW_FLASHLIGHT_SETTINGS
+            MACRO_VIS_POINTER_SETTINGS
         };
     };
     MRT_SwitchItemNextClass = QCLASS(LLM_Laser_Black);
     MRT_SwitchItemPrevClass = QCLASS(LLM_Low_Light_Black);
+    MRT_SwitchItemHintText = CSTRING(Visible_Laser);
+    ACE_LaserPointer = 1;
 };
 

--- a/addons/flashlight/Surefire_Flashlights.hpp
+++ b/addons/flashlight/Surefire_Flashlights.hpp
@@ -11,6 +11,7 @@ class CLASS(Surefire_Flashlight_Black): cup_acc_flashlight {
     };
     MRT_SwitchItemNextClass = QCLASS(Surefire_Low_Flashlight_Black);
     MRT_SwitchItemPrevClass = QCLASS(Surefire_Low_Flashlight_Black);
+    MRT_SwitchItemHintText = CSTRING(High_Power_Light);
 };
 
 class CLASS(Surefire_Low_Flashlight_Black): cup_acc_flashlight {
@@ -25,6 +26,7 @@ class CLASS(Surefire_Low_Flashlight_Black): cup_acc_flashlight {
     };
     MRT_SwitchItemNextClass = QCLASS(Surefire_Flashlight_Black);
     MRT_SwitchItemPrevClass = QCLASS(Surefire_Flashlight_Black);
+    MRT_SwitchItemHintText = CSTRING(Low_Power_Light);
 };
 
 class CUP_acc_Flashlight_wdl;
@@ -40,6 +42,7 @@ class CLASS(Surefire_Flashlight_OD): CUP_acc_Flashlight_wdl {
     };
     MRT_SwitchItemNextClass = QCLASS(Surefire_Low_Flashlight_OD);
     MRT_SwitchItemPrevClass = QCLASS(Surefire_Low_Flashlight_OD);
+    MRT_SwitchItemHintText = CSTRING(High_Power_Light);
 };
 
 class CLASS(Surefire_Low_Flashlight_OD): CUP_acc_Flashlight_wdl {
@@ -54,6 +57,7 @@ class CLASS(Surefire_Low_Flashlight_OD): CUP_acc_Flashlight_wdl {
     };
     MRT_SwitchItemNextClass = QCLASS(Surefire_Flashlight_OD);
     MRT_SwitchItemPrevClass = QCLASS(Surefire_Flashlight_OD);
+    MRT_SwitchItemHintText = CSTRING(Low_Power_Light);
 };
 
 class CUP_acc_Flashlight_desert;
@@ -69,6 +73,7 @@ class CLASS(Surefire_Flashlight_Tan): CUP_acc_Flashlight_desert {
     };
     MRT_SwitchItemNextClass = QCLASS(Surefire_Low_Flashlight_Tan);
     MRT_SwitchItemPrevClass = QCLASS(Surefire_Low_Flashlight_Tan);
+    MRT_SwitchItemHintText = CSTRING(High_Power_Light);
 };
 
 class CLASS(Surefire_Low_Flashlight_Tan): CUP_acc_Flashlight_desert {
@@ -83,4 +88,5 @@ class CLASS(Surefire_Low_Flashlight_Tan): CUP_acc_Flashlight_desert {
     };
     MRT_SwitchItemNextClass = QCLASS(Surefire_Flashlight_Tan);
     MRT_SwitchItemPrevClass = QCLASS(Surefire_Flashlight_Tan);
+    MRT_SwitchItemHintText = CSTRING(Low_Power_Light);
 };

--- a/addons/flashlight/stringtable.xml
+++ b/addons/flashlight/stringtable.xml
@@ -4,6 +4,18 @@
         <Key ID="STR_TACGT_Flashlight_Author">
             <English>Tyrone</English>
         </Key>
+        <Key ID="STR_TACGT_Flashlight_Laser_Pointer">
+            <English>IR Laser</English>
+        </Key>
+        <Key ID="STR_TACGT_Flashlight_Visible_Laser">
+            <English>Visible Laser</English>
+        </Key>
+        <Key ID="STR_TACGT_Flashlight_High_Power_Light">
+            <English>Flashlight Blue</English>
+        </Key>
+        <Key ID="STR_TACGT_Flashlight_Low_Power_Light">
+            <English>Flashlight Red</English>
+        </Key>
         <Key ID="STR_TACGT_Flashlight_Description">
             <English>GT Edition Blue Flashlight.</English>
         </Key>
@@ -44,7 +56,7 @@
             <English>LLM01 Black (GT Edition)</English>
         </Key>
         <Key ID="STR_TACGT_Flashlight_LLM_Laser_Light_Black_Display">
-            <English>LLM MKIII Tan (GT Edition)</English>
+            <English>LLM MKIII (GT Edition)</English>
         </Key>
     </Package>
 </Project>


### PR DESCRIPTION
Added names for attachment states:
- Flashlight Blue
- Flashlight Red
- IR Laser
- Visible Laser
---
- Fixed name of LLM MKIII
- Fixed Visible pointer of LLM MKIII
