### PR TITLE
Expand 9x19 Ammunition & MP5 model fix

### DIFF
--- a/addons/ammunition/9x19.hpp
+++ b/addons/ammunition/9x19.hpp
@@ -1,0 +1,49 @@
+// Vanilla 9x19 - "Clear" Magazine
+class CLASS(30Rnd_9x19_Clear_7N21): 30Rnd_9x21_Mag_SMG_02 {
+    author = "TyroneMF";
+    scope = 2;
+    lastRoundsTracer = 4;
+    displayName = CSTRING(30Rnd_9x19_Clear_7N21_Name);
+    displayNameShort = CSTRING(30Rnd_9x19_7N21_Name_Short);
+    ammo = QCLASS(9x19_7N21);
+    mass = 8;
+};
+
+class CLASS(30Rnd_9x19_Clear_7N21_Green): CLASS(30Rnd_9x19_Clear_7N21) {
+    scope = 2;
+    tracersEvery = 1;
+    displayName = CSTRING(30Rnd_9x19_Clear_7N21_Green_Name);
+};
+
+// Regular Magazine
+class CLASS(30Rnd_9x19_7N21): 30Rnd_9x21_Mag {
+    author = "TyroneMF";
+    scope = 2;
+    lastRoundsTracer = 4;
+    displayName = CSTRING(30Rnd_9x19_7N21);
+    displayNameShort = CSTRING(30Rnd_9x19_7N21_Name_Short);
+    ammo = QCLASS(9x19_7N21);
+    mass = 8;
+};
+
+class CLASS(30Rnd_9x19_7N21_Green): CLASS(30Rnd_9x19_7N21) {
+    scope = 2;
+    tracersEvery = 1;
+    displayName = CSTRING(30Rnd_9x19_7N21_Green_Name);
+};
+
+// CUP MP5 Magazine
+class CLASS(30Rnd_9x19_MP5_7N21): CUP_30Rnd_9x19_MP5 {
+    author = "TyroneMF";
+    scope = 2;
+    lastRoundsTracer = 4;
+    displayName = CSTRING(30Rnd_9x19_MP5_7N21_Name);
+    ammo = QCLASS(9x19_7N21);
+    mass = 8;
+};
+
+class CLASS(30Rnd_9x19_MP5_7N21_Green): CLASS(30Rnd_9x19_MP5_7N21) {
+    scope = 2;
+    tracersEvery = 1;
+    displayName = CSTRING(30Rnd_9x19_MP5_7N21_Green_Name);
+};

--- a/addons/ammunition/CfgAmmo.hpp
+++ b/addons/ammunition/CfgAmmo.hpp
@@ -1,5 +1,6 @@
 class CfgAmmo {
     class BulletBase;
+    class B_9x21_Ball_Tracer_Green;
     class B_545x39_Ball_F;
     class B_580x42_Ball_F;
     class B_556x45_Ball;
@@ -7,6 +8,13 @@ class CfgAmmo {
     class B_12Gauge_Pellets_Submunition;
     class B_12Gauge_Pellets_Submunition_Deploy;
     class CUP_B_762x54_Ball_White_Tracer;
+
+    // 9mm ammo
+    class CLASS(9x19_7N21): B_9x21_Ball_Tracer_Green {
+        caliber = 1.4;
+        hit = 6.5;
+        typicalSpeed = 365;
+    };
 
     // 12G ammo
     class CLASS(12g_Pellets_Submunition): B_12Gauge_Pellets_Submunition {

--- a/addons/ammunition/CfgMagazineWells.hpp
+++ b/addons/ammunition/CfgMagazineWells.hpp
@@ -1,4 +1,21 @@
 class CfgMagazineWells {
+    class CLASS(9x19_MP5) { // Prevents regular BI Magazines fitting the CUP MP5s as no model shows.
+        ADDON[] = {
+            "CUP_30Rnd_9x19_MP5",
+            QCLASS(30Rnd_9x19_MP5_7N21),
+            QCLASS(30Rnd_9x19_MP5_7N21_Green)
+        };
+    };
+
+    class CBA_9x19_MP5 {
+        ADDON[] = {
+            QCLASS(30Rnd_9x19_Clear_7N21),
+            QCLASS(30Rnd_9x19_Clear_7N21_Green),
+            QCLASS(30Rnd_9x19_7N21),
+            QCLASS(30Rnd_9x19_7N21_Green)
+        };
+    };
+
     class CBA_12g_2rnds {
         ADDON[] = {
             QCLASS(2Rnd_P_000)

--- a/addons/ammunition/CfgMagazines.hpp
+++ b/addons/ammunition/CfgMagazines.hpp
@@ -24,7 +24,11 @@ class CfgMagazines {
     class CUP_30Rnd_556x45_G36;
     class CUP_60Rnd_556x45_SureFire;
     class hlc_30Rnd_556x45_EPR_sg550;
+    class 30Rnd_9x21_Mag_SMG_02;
+    class 30Rnd_9x21_Mag;
+    class CUP_30Rnd_9x19_MP5;
 
+#include "9x19.hpp"
 #include "12g.hpp"
 #include "545x39.hpp"
 #include "556x45.hpp"

--- a/addons/ammunition/config.cpp
+++ b/addons/ammunition/config.cpp
@@ -71,7 +71,13 @@ class CfgPatches {
             QCLASS(75Rnd_762x39_RPK_BP_Mag),
             QCLASS(20Rnd_762x51_FAL_AP_Mag),
             QCLASS(30Rnd_762x51_FAL_AP_Mag),
-            QCLASS(10Rnd_762x54_SVD_AP_Mag)
+            QCLASS(10Rnd_762x54_SVD_AP_Mag),
+            QCLASS(30Rnd_9x19_Clear_7N21),
+            QCLASS(30Rnd_9x19_Clear_7N21_Green),
+            QCLASS(30Rnd_9x19_7N21),
+            QCLASS(30Rnd_9x19_7N21_Green),
+            QCLASS(30Rnd_9x19_MP5_7N21),
+            QCLASS(30Rnd_9x19_MP5_7N21_Green)
         };
         author = ECSTRING(main,Author);
         authors[] = {"TyroneMF"};

--- a/addons/ammunition/stringtable.xml
+++ b/addons/ammunition/stringtable.xml
@@ -1,6 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project name="TACGT">
     <Package name="Ammunition">
+        <Key ID="STR_TACGT_Ammunition_30Rnd_9x19_Clear_7N21_Name">
+            <English>9mm 30Rnd Clear [RT] Green (7N21)</English>
+        </Key>
+        <Key ID="STR_TACGT_Ammunition_30Rnd_9x19_Clear_7N21_Green_Name">
+            <English>9mm 30Rnd Clear [T] Green (7N21)</English>
+        </Key>
+        <Key ID="STR_TACGT_Ammunition_30Rnd_9x19_7N21_Name_Short">
+            <English>7N21 Rounds</English>
+        </Key>
+        <Key ID="STR_TACGT_Ammunition_30Rnd_9x19_7N21">
+            <English>9mm 30Rnd [RT] Green (7N21)</English>
+        </Key>
+        <Key ID="STR_TACGT_Ammunition_30Rnd_9x19_7N21_Green_Name">
+            <English>9mm 30Rnd [T] Green (7N21)</English>
+        </Key>
+        <Key ID="STR_TACGT_Ammunition_30Rnd_9x19_MP5_7N21_Name">
+            <English>9mm 30Rnd MP5 [RT] Green (7N21)</English>
+        </Key>
+        <Key ID="STR_TACGT_Ammunition_30Rnd_9x19_MP5_7N21_Green_Name">
+            <English>9mm 30Rnd MP5 [T] Green (7N21)</English>
+        </Key>
         <Key ID="STR_TACGT_Ammunition_8Rnd_P_000_Name">
             <English>8Rnd #00 Magnum Shells</English>
             <French>8Rnd #00 Cartouches de chevrotine</French>

--- a/addons/mp5/$PBOPREFIX$
+++ b/addons/mp5/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\tacgt\addons\mp5

--- a/addons/mp5/CfgWeapons.hpp
+++ b/addons/mp5/CfgWeapons.hpp
@@ -1,0 +1,12 @@
+class CfgWeapons {
+    class Rifle_Base_F;
+    class CUP_smg_MP5SD6: Rifle_Base_F {
+        magazines[] = {
+            QCLASS(30Rnd_9x19_MP5_7N21),
+            QCLASS(30Rnd_9x19_MP5_7N21_Green)
+        };
+        magazineWell[] = {
+            QCLASS(9x19_MP5)
+        };
+    };
+};

--- a/addons/mp5/config.cpp
+++ b/addons/mp5/config.cpp
@@ -1,0 +1,18 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        magazines[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"tacgt_main", "CUP_Weapons_MP5"};
+        author = ECSTRING(main,Author);
+        authors[] = {"TyroneMF"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgWeapons.hpp"

--- a/addons/mp5/config.cpp
+++ b/addons/mp5/config.cpp
@@ -7,7 +7,7 @@ class CfgPatches {
         weapons[] = {};
         magazines[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"tacgt_main", "CUP_Weapons_MP5"};
+        requiredAddons[] = {"tacgt_main", "tacgt_ammunition", "CUP_Weapons_MP5"};
         author = ECSTRING(main,Author);
         authors[] = {"TyroneMF"};
         url = ECSTRING(main,URL);

--- a/addons/mp5/script_component.hpp
+++ b/addons/mp5/script_component.hpp
@@ -1,0 +1,4 @@
+#define COMPONENT mp5
+#define COMPONENT_BEAUTIFIED MP5
+#include "\x\tacgt\addons\main\script_mod.hpp"
+#include "\x\tacgt\addons\main\script_macros.hpp"

--- a/addons/rename/README.md
+++ b/addons/rename/README.md
@@ -13,6 +13,7 @@
 
 ##### 9x19
 - Luger: Standard Ball round.
+- 7N21: Armour piercing round.
 
 ##### 5.45x39
 - PS: Standard steel-core round.


### PR DESCRIPTION
MP5 Fix:
Easy workaround by changing it's magwell to it's own class so it can only access CUP MP5 magazines which show on the model.

7N21 Ammunition for CUP MP5/All Vanilla 9x19 weapons.