### PR TITLE
Add Optional RPG Component

### DIFF
--- a/optionals/rpg/$PBOPREFIX$
+++ b/optionals/rpg/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\tacgt\addons\rpg

--- a/optionals/rpg/CfgAmmo.hpp
+++ b/optionals/rpg/CfgAmmo.hpp
@@ -1,0 +1,41 @@
+class CfgAmmo {
+    class RocketBase;
+
+    // Vanilla Ammunition
+    class R_PG7_F: RocketBase {
+        MACRO_RPG_AMMO
+    };
+
+    class R_PG32V_F: RocketBase {
+        MACRO_RPG_AMMO
+    };
+
+    class R_MRAAWS_HEAT_F: RocketBase {
+        MACRO_RPG_AMMO
+    };
+
+    // CUP Ammunition
+    class CUP_R_OG7_AT: RocketBase {
+        MACRO_RPG_AMMO
+    };
+
+    class CUP_R_PG7V_AT: RocketBase {
+        MACRO_RPG_AMMO
+    };
+
+    class CUP_R_PG7VL_AT: RocketBase {
+        MACRO_RPG_AMMO
+    };
+
+    class CUP_R_PG7VM_AT: RocketBase {
+        MACRO_RPG_AMMO
+    };
+
+    class CUP_R_PG7VR_AT: RocketBase {
+        MACRO_RPG_AMMO
+    };
+
+    class CUP_R_TBG7V_AT: RocketBase {
+        MACRO_RPG_AMMO
+    };
+};

--- a/optionals/rpg/CfgWeapons.hpp
+++ b/optionals/rpg/CfgWeapons.hpp
@@ -1,0 +1,33 @@
+class CfgWeapons {
+    class Launcher_Base_F;
+
+    // Vanilla RPG-7
+    class launch_RPG7_F: Launcher_Base_F {
+        class Single: Mode_SemiAuto {
+            minRange = 50;
+            minRangeProbab = 0.25;
+            midRange = 300;
+            midRangeProbab = 0.25;
+            maxRange = 600;
+            maxRangeProbab = 0.25;
+            aiRateOfFire = 7;
+            aiRateOfFireDistance = 250;
+            aiRateOfFireDispersion = 7;
+        };
+    };
+
+    // CUP RPG-7
+    class CUP_launch_RPG7V: Launcher_Base_F {
+        class Single: Mode_SemiAuto {
+            minRange = 50;
+            minRangeProbab = 0.25;
+            midRange = 300;
+            midRangeProbab = 0.25;
+            maxRange = 600;
+            maxRangeProbab = 0.25;
+            aiRateOfFire = 7;
+            aiRateOfFireDistance = 250;
+            aiRateOfFireDispersion = 7;
+        };
+    };
+};

--- a/optionals/rpg/config.cpp
+++ b/optionals/rpg/config.cpp
@@ -1,0 +1,21 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        magazines[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"tacgt_main", "CUP_Weapons_RPG7", "CUP_Weapons_Ammunition"};
+        author = ECSTRING(main,Author);
+        authors[] = {"TyroneMF"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+class Mode_SemiAuto;
+
+#include "CfgAmmo.hpp"
+#include "CfgWeapons.hpp"

--- a/optionals/rpg/script_component.hpp
+++ b/optionals/rpg/script_component.hpp
@@ -1,0 +1,10 @@
+#define COMPONENT rpg
+#define COMPONENT_BEAUTIFIED RPG
+#include "\x\tacgt\addons\main\script_mod.hpp"
+#include "\x\tacgt\addons\main\script_macros.hpp"
+
+#define MACRO_RPG_AMMO \
+    aiAmmoUsageFlags = "64 + 128 + 256 + 512"; \
+    airLock = 1; \
+    allowAgainstInfantry = 1; \
+    cost = 30;


### PR DESCRIPTION
- Allows AI to fire RPGs at infantry.

Set this as an optional because even i don't know if this is a good idea. Would require some serious testing before being implemented permanently.