### PR TITLE
Add Bnae component

### DIFF
--- a/addons/bnae/$PBOPREFIX$
+++ b/addons/bnae/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\tacgt\addons\bnae

--- a/addons/bnae/CfgWeapons.hpp
+++ b/addons/bnae/CfgWeapons.hpp
@@ -1,0 +1,12 @@
+class CfgWeapons {
+    class bnae_rk95_base;
+    class bnae_rk95_virtual: bnae_rk95_base {
+        class WeaponSlotsInfo;
+    };
+
+    class bnae_rk95r_virtual: bnae_rk95_virtual {
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 100;
+        };
+    };
+};

--- a/addons/bnae/config.cpp
+++ b/addons/bnae/config.cpp
@@ -1,0 +1,18 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        magazines[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"tacgt_main", "bnae_RK95", "tac_bnae_rk95_compat_ace"};
+        author = ECSTRING(main,Author);
+        authors[] = {"TyroneMF"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgWeapons.hpp"

--- a/addons/bnae/script_component.hpp
+++ b/addons/bnae/script_component.hpp
@@ -1,0 +1,4 @@
+#define COMPONENT bnae
+#define COMPONENT_BEAUTIFIED Bnae
+#include "\x\tacgt\addons\main\script_mod.hpp"
+#include "\x\tacgt\addons\main\script_macros.hpp"


### PR DESCRIPTION
- Fixes RK-95 railed that had no weight and couldn't take suppressors. (Creates a UBC error, but so does the ACE compat fix)