### PR TITLE
Recoil - Fix Sig SG rifle recoil and tweak LAMG recoil

### DIFF
--- a/addons/lamg/CfgRecoils.hpp
+++ b/addons/lamg/CfgRecoils.hpp
@@ -1,7 +1,7 @@
 class CfgRecoils {
     class recoil_default;
     class recoil_mk200: recoil_default {
-        muzzleOuter[] = {0.3, 0.7, 0.5, 0.2};
+        muzzleOuter[] = {0.3, 0.7, 0.4, 0.2};
         kickBack[] = {0.02, 0.04};
         temporary = 0.005;
     };

--- a/addons/recoil/CfgWeapons.hpp
+++ b/addons/recoil/CfgWeapons.hpp
@@ -5,4 +5,9 @@ class CfgWeapons {
     class CUP_arifle_HK416_145_Base: Rifle_Base_F {
         recoil = "recoil_spar";
     };
+
+    // NiArms Sig SG-x series. (Jumps way too much compared to other weapons)
+    class hlc_sg550_base: Rifle_Base_F {
+        recoil = "recoil_spar";
+    };
 };

--- a/addons/recoil/config.cpp
+++ b/addons/recoil/config.cpp
@@ -7,7 +7,7 @@ class CfgPatches {
         weapons[] = {};
         magazines[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"tacgt_main", "CUP_Weapons_HK416"};
+        requiredAddons[] = {"tacgt_main", "CUP_Weapons_HK416", "hlcweapons_SG550"};
         author = ECSTRING(main,Authors);
         authors[] = {"Tyrone"};
         url = ECSTRING(main,URL);


### PR DESCRIPTION

- all SIG SGxxx rifles have abnormal vertical recoil, changed to the Spar-16 from APEX.
- LAMG horizontal recoil spread is still high, lowered by 0.1.