### PR TITLE
LAMG - Improve LAMG Recoil Spread

### DIFF
--- a/addons/lamg/CfgRecoils.hpp
+++ b/addons/lamg/CfgRecoils.hpp
@@ -5,4 +5,10 @@ class CfgRecoils {
         kickBack[] = {0.02, 0.04};
         temporary = 0.005;
     };
+    // LAMG more manageable recoil due to weight reduction from ammo.
+    class CLASS(recoil_mk200): recoil_mk200 {
+        muzzleOuter[] = {0.25, 0.55, 0.35, 0.2};
+        kickBack[] = {0.02, 0.03};
+        temporary = 0.004;
+    };
 };

--- a/addons/lamg/CfgWeapons.hpp
+++ b/addons/lamg/CfgWeapons.hpp
@@ -5,6 +5,7 @@ class CfgWeapons {
         scope = 2;
         displayName = CSTRING(LMG_LAMG_Display);
         descriptionShort = CSTRING(LMG_LAMG_Description);
+        recoil = QCLASS(recoil_mk200);
         magazines[] = {
             QCLASS(100Rnd_65x39_Cased_Box),
             QCLASS(100Rnd_65x39_Yellow_Cased_Box)


### PR DESCRIPTION
- Split LAMG / Stoner 99 recoils.
- LAMG recoil has a tighter spread than regular Stoner 99 to differentiate between weight difference.