### PR TITLE
Add Distance component

### DIFF
--- a/addons/distance/$PBOPREFIX$
+++ b/addons/distance/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\tacgt\addons\distance

--- a/addons/distance/CfgVehicles.hpp
+++ b/addons/distance/CfgVehicles.hpp
@@ -1,0 +1,6 @@
+class CfgVehicles {
+    class Land;
+    class Man: Land {
+        sensitivity = 5;
+    };
+};

--- a/addons/distance/config.cpp
+++ b/addons/distance/config.cpp
@@ -1,0 +1,18 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        magazines[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"tacgt_main"};
+        author = ECSTRING(main,Authors);
+        authors[] = {"Tyrone"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgVehicles.hpp"

--- a/addons/distance/script_component.hpp
+++ b/addons/distance/script_component.hpp
@@ -1,0 +1,4 @@
+#define COMPONENT distance
+#define COMPONENT_BEAUTIFIED Distance
+#include "\x\tacgt\addons\main\script_mod.hpp"
+#include "\x\tacgt\addons\main\script_macros.hpp"


### PR DESCRIPTION
- Increasing the base sensitivity of units from it's default (~1) to a higher number gives AI improved spotting for longer range engagements and less potato'y standing around.

Will do some heavy testing to see the impact before merging.