### PR TITLE
RPG - Add ACE fragmentation to RPG7 frag rocket

### DIFF
--- a/addons/rpg/CfgAmmo.hpp
+++ b/addons/rpg/CfgAmmo.hpp
@@ -35,6 +35,12 @@ class CfgAmmo {
     // OG-7V (Frag) Rocket
     class CUP_R_OG7_AT: RocketBase {
         MACRO_RPG_AMMO
+        ace_frag_enabled = 1;
+        ace_frag_metal = 350;
+        ace_frag_charge = 210;
+        ace_frag_gurney_c = 2800;
+        ace_Frag_gurney_k = 3/5;
+        ace_frag_classes[] = {"ACE_frag_medium_HD"};
     };
 
     // PG-7V (HEAT) Rocket


### PR DESCRIPTION
- title.
- Used RPG32 HE round as baseline.
