### PR TITLE
Ammunition - Add missing magwells

### DIFF
--- a/addons/ammunition/CfgWeapons.hpp
+++ b/addons/ammunition/CfgWeapons.hpp
@@ -1,6 +1,11 @@
 class CfgWeapons {
 
     // Any missing Magazine Wells are added here.
+    class pdw2000_base_F;
+    class hgun_PDW2000_F: pdw2000_base_F {
+        magazineWell[] = {"CBA_9x19_ScorpionEvo3"};
+    };
+
     class Rifle_Long_Base_F;
     class DMR_07_base_F: Rifle_Long_Base_F {
         magazineWell[] = {"CBA_65x39_QBU"};
@@ -32,5 +37,15 @@ class CfgWeapons {
     class bnae_rk95_base;
     class bnae_rk95_virtual: bnae_rk95_base {
         magazineWell[] = {"CBA_762x39_AK"};
+    };
+
+    class CUP_arifle_Mk17_STD;
+    class CUP_arifle_Mk17_STD_EGLM: CUP_arifle_Mk17_STD {
+        magazineWell[] = {"CBA_762x51_SCAR"};
+    };
+
+    class CUP_arifle_Mk17_CQC;
+    class CUP_arifle_Mk17_CQC_EGLM: CUP_arifle_Mk17_CQC {
+        magazineWell[] = {"CBA_762x51_SCAR"};
     };
 };

--- a/addons/ammunition/CfgWeapons.hpp
+++ b/addons/ammunition/CfgWeapons.hpp
@@ -48,4 +48,9 @@ class CfgWeapons {
     class CUP_arifle_Mk17_CQC_EGLM: CUP_arifle_Mk17_CQC {
         magazineWell[] = {"CBA_762x51_SCAR"};
     };
+
+    class bnae_r1_base;
+    class bnae_r1_virtual: bnae_r1_base {
+        magazineWell[] = {"ACPC2_45ACP","CBA_45ACP_1911"};
+    };
 };

--- a/addons/ammunition/config.cpp
+++ b/addons/ammunition/config.cpp
@@ -17,7 +17,8 @@ class CfgPatches {
             "CUP_Weapons_X95",
             "hlcweapons_core",
             "hlcweapons_AUG",
-            "hlcweapons_SG550"
+            "hlcweapons_SG550",
+            "bnae_r1_virtual"
         };
         author = ECSTRING(main,Authors);
         authors[] = {"Mike"};


### PR DESCRIPTION
Added missing magwells to:
- SCAR-H EGLM & Black variant
- SCAR-H CQC EGLM & Black variant
- PDW
- R1 Enhanced