### PR TITLE
Ammunition - New PMAG model without QP

### DIFF
--- a/addons/ammunition/magazines/556x45.hpp
+++ b/addons/ammunition/magazines/556x45.hpp
@@ -63,19 +63,19 @@ class CLASS(30Rnd_556x45_AP_PMAG): CLASS(30Rnd_556x45_AP_EMAG) {
 // 5.56x45mm (PMAG, Tan)
 class CLASS(30Rnd_556x45_Ball_PMAG_Tan): CLASS(30Rnd_556x45_Ball_PMAG) {
     MACRO_556_MAGAZINE_PMAG_Tan
-    displayName = "5.56mm 30Rnd PMAG Tan (Ball)";
+    displayName = "5.56mm 30Rnd PMAG Coyote (Ball)";
 };
 class CLASS(30Rnd_556x45_Ball_Tracer_PMAG_Tan): CLASS(30Rnd_556x45_Ball_Tracer_PMAG) {
     MACRO_556_MAGAZINE_PMAG_Tan
-    displayName = "5.56mm 30Rnd PMAG Tan [T] (Ball)";
+    displayName = "5.56mm 30Rnd PMAG Coyote [T] (Ball)";
 };
 class CLASS(30Rnd_556x45_EPR_PMAG_Tan): CLASS(30Rnd_556x45_EPR_PMAG) {
     MACRO_556_MAGAZINE_PMAG_Tan
-    displayName = "5.56mm 30Rnd PMAG Tan (EPR)";
+    displayName = "5.56mm 30Rnd PMAG Coyote (EPR)";
 };
 class CLASS(30Rnd_556x45_AP_PMAG_Tan): CLASS(30Rnd_556x45_AP_PMAG) {
     MACRO_556_MAGAZINE_PMAG_Tan
-    displayName = "5.56mm 30Rnd PMAG Tan (AP)";
+    displayName = "5.56mm 30Rnd PMAG Coyote (AP)";
 };
 
 // 5.56x45mm Belt

--- a/addons/ammunition/script_component.hpp
+++ b/addons/ammunition/script_component.hpp
@@ -32,14 +32,16 @@
 
 #define MACRO_556_MAGAZINE_PMAG_Black \
     hiddenSelections[] = {"Camo1"}; \
-    hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\pmag_black_co.paa"}; \
-    model = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines\CUP_mag_30rnd_pmag_qp.p3d"; \
-    modelSpecial = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines_proxy\CUP_mag_30rnd_pmag_qp.p3d"; \
-    modelSpecialIsProxy = 1;
+    hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\cup_pmag_black_co.paa"}; \
+    model = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines\CUP_mag_30rnd_pmag.p3d"; \
+    modelSpecial = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines_proxy\CUP_mag_30rnd_pmag.p3d"; \
+    modelSpecialIsProxy = 1; \
+    picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_30rnd_pmag_black_ca.paa";
 
 #define MACRO_556_MAGAZINE_PMAG_Tan \
     hiddenSelections[] = {"Camo1"}; \
-    hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\pmag_coyote_co.paa"};
+    hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\cup_pmag_coyote_co.paa"}; \
+    picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_30rnd_pmag_coyote_ca.paa";
 
 #define MACRO_556_MAGAZINE_EMAG_Black \
     hiddenSelections[] = {"Camo1"}; \


### PR DESCRIPTION
- Uses new CUP PMAG without the QP and fixes the UI issue.
- Renames Tan to Coyote because "Shit-Brown" isn't tan.

fix (#120) fix (#121)