### PR TITLE
Add AI Ammunition Component

### DIFF
--- a/addons/ammunition/CfgAmmo.hpp
+++ b/addons/ammunition/CfgAmmo.hpp
@@ -217,7 +217,8 @@ class CfgAmmo {
         hit = 12;
     };
     class CLASS(68x43_AP): CLASS(68x43_EPR) {
-        caliber = 12.5;
+        caliber = 2.3;
+        hit = 12.5;
     };
 
     // 7.62x39mm

--- a/addons/ammunition/CfgWeapons.hpp
+++ b/addons/ammunition/CfgWeapons.hpp
@@ -32,6 +32,10 @@ class CfgWeapons {
         magazineWell[] = {QCLASS(45ACP_MAC10)};
     };
 
+    class CUP_hgun_Mac10: CUP_Mac10_Base {
+        magazineWell[] = {QCLASS(45ACP_MAC10)};
+    };
+
     class CUP_hgun_TEC9: Pistol_Base_F {
         magazineWell[] = {QCLASS(9x19_TEC9)};
     };
@@ -77,6 +81,10 @@ class CfgWeapons {
     class CUP_arifle_Mk17_CQC;
     class CUP_arifle_Mk17_CQC_EGLM: CUP_arifle_Mk17_CQC {
         magazineWell[] = {"CBA_762x51_SCAR"};
+    };
+
+    class CUP_arifle_ACR_EGLM_blk_556: CUP_arifle_ACR_BASE_556 {
+        magazineWell[] += {"CBA_556x45_STANAG"};
     };
 
     class bnae_r1_base;

--- a/addons/ammunition/CfgWeapons.hpp
+++ b/addons/ammunition/CfgWeapons.hpp
@@ -27,6 +27,15 @@ class CfgWeapons {
         magazineWell[] = {"CBA_45ACP_MK23"};
     };
 
+    class CUP_Mac10_Base;
+    class CUP_smg_MAC10: CUP_Mac10_Base {
+        magazineWell[] = {QCLASS(45ACP_MAC10)};
+    };
+
+    class CUP_hgun_TEC9: Pistol_Base_F {
+        magazineWell[] = {QCLASS(9x19_TEC9)};
+    };
+
     class Rifle_Long_Base_F;
     class DMR_07_base_F: Rifle_Long_Base_F {
         magazineWell[] = {"CBA_65x39_QBU"};

--- a/addons/ammunition/CfgWeapons.hpp
+++ b/addons/ammunition/CfgWeapons.hpp
@@ -32,7 +32,8 @@ class CfgWeapons {
         magazineWell[] = {QCLASS(45ACP_MAC10)};
     };
 
-    class CUP_hgun_Mac10: CUP_Mac10_Base {
+    class CUP_hgun_Mac10_Base;
+    class CUP_hgun_Mac10: CUP_hgun_Mac10_Base {
         magazineWell[] = {QCLASS(45ACP_MAC10)};
     };
 
@@ -83,7 +84,8 @@ class CfgWeapons {
         magazineWell[] = {"CBA_762x51_SCAR"};
     };
 
-    class CUP_arifle_ACR_EGLM_blk_556: CUP_arifle_ACR_BASE_556 {
+    class CUP_arifle_ACR_EGLM_BASE_556;
+    class CUP_arifle_ACR_EGLM_blk_556: CUP_arifle_ACR_EGLM_BASE_556 {
         magazineWell[] += {"CBA_556x45_STANAG"};
     };
 

--- a/addons/ammunition_ai/$PBOPREFIX$
+++ b/addons/ammunition_ai/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\tacgt\addons\ammunitionai

--- a/addons/ammunition_ai/CfgAmmo.hpp
+++ b/addons/ammunition_ai/CfgAmmo.hpp
@@ -1,0 +1,104 @@
+class CfgAmmo {
+ /*
+  * Ammunition used for AI only. Won't be labelled as AP/EPR/Ball, designed around giving players a challenge and weaker enemies still being lethal.
+  * Shotgun ammunition can be the same or Vanilla.
+  * High calibers (7.62x54r or above should be Vanilla)
+  * .300AAC / 9x39 Subsonic should just use whatever is available
+  */
+
+    // 9x19
+    class B_9x21_Ball_Tracer_Red;
+    class CLASS(AI_9x19): B_9x21_Ball_Tracer_Red {
+        aiAmmoUsageFlags = "64 + 128";
+        caliber = 1;
+        hit = 9;
+        MACRO_TRACERS
+    };
+
+    // .45ACP
+    class B_45ACP_Ball;
+    class CLASS(AI_45ACP): B_45ACP_Ball {
+        aiAmmoUsageFlags = "64 + 128";
+        caliber = 0.65;
+        hit = 11.5;
+        MACRO_TRACERS
+    };
+
+    // 4.6x30
+    class CUP_B_46x30_Ball_Tracer_Red;
+    class CLASS(AI_46x30): CUP_B_46x30_Ball_Tracer_Red {
+        aiAmmoUsageFlags = "64 + 128";
+        caliber = 1;
+        hit = 9.3;
+        MACRO_TRACERS
+    };
+
+    // 5.45x39
+    class B_545x39_Ball_Green_F;
+    class CLASS(AI_545x39): B_545x39_Ball_Green_F {
+        aiAmmoUsageFlags = "64 + 128";
+        caliber = 1.1;
+        hit = 11.3;
+        MACRO_TRACERS
+    };
+
+    // 5.56x45
+    class B_556x45_Ball;
+    class CLASS(AI_556x45): B_556x45_Ball {
+        aiAmmoUsageFlags = "64 + 128";
+        caliber = 1.7;
+        hit = 12.3;
+        MACRO_TRACERS
+    };
+
+    // 5.7x28
+    class CUP_B_570x28_Ball_Tracer_Red;
+    class CLASS(AI_57x28): CUP_B_570x28_Ball_Tracer_Red {
+        aiAmmoUsageFlags = "64 + 128";
+        caliber = 1.6;
+        hit = 13;
+        MACRO_TRACERS
+    };
+
+    // 5.8x42
+    class B_580x42_Ball_F;
+    class CLASS(AI_58x42): B_580x42_Ball_F {
+        aiAmmoUsageFlags = "64 + 128";
+        caliber = 1.4;
+        hit = 10.7;
+        MACRO_TRACERS
+    };
+
+    // 6.5x39
+    class B_65x39_Caseless;
+    class CLASS(AI_65x39): B_65x39_Caseless {
+        aiAmmoUsageFlags = "64 + 128";
+        caliber = 1.8;
+        hit = 12;
+        MACRO_TRACERS
+    };
+
+    // 6.8x43
+    class CLASS(AI_68x43): CLASS(AI_65x39) {
+        caliber = 2;
+        hit = 12.3;
+    };
+
+    // 7.62x39
+    class B_762x39_Ball_F;
+    class CLASS(AI_762x39): B_762x39_Ball_F {
+        aiAmmoUsageFlags = "64 + 128";
+        caliber = 1.68;
+        hit = 12.5;
+        MACRO_TRACERS
+    };
+
+    // 7.62x51
+    class B_762x51_Ball;
+    class CLASS(AI_762x51): B_762x51_Ball {
+        aiAmmoUsageFlags = "64 + 128";
+        caliber = 2;
+        hit = 14;
+        MACRO_TRACERS
+    };
+};

--- a/addons/ammunition_ai/CfgMagazineWells.hpp
+++ b/addons/ammunition_ai/CfgMagazineWells.hpp
@@ -60,6 +60,18 @@ class CfgMagazineWells {
         };
     };
 
+    class CLASS(9x19_TEC9) {
+        ADDON[] = {
+            QCLASS(AI_32Rnd_9x19_TEC9)
+        };
+    };
+
+    class CBA_9x19_UZI {
+        ADDON[] = {
+            QCLASS(AI_32Rnd_9x19_UZI)
+        };
+    };
+
     class CBA_45ACP_FNX45 {
         ADDON[] = {
             QCLASS(AI_11Rnd_45ACP_FNX)
@@ -75,6 +87,12 @@ class CfgMagazineWells {
     class CBA_45ACP_1911 {
         ADDON[] = {
             QCLASS(AI_8Rnd_45ACP_1911)
+        };
+    };
+
+    class CLASS(45ACP_MAC10) {
+        ADDON[] = {
+            QCLASS(AI_30Rnd_45ACP_MAC10)
         };
     };
 

--- a/addons/ammunition_ai/CfgMagazineWells.hpp
+++ b/addons/ammunition_ai/CfgMagazineWells.hpp
@@ -160,7 +160,8 @@ class CfgMagazineWells {
 
     class CBA_556x45_G36 {
         ADDON[] = {
-            QCLASS(AI_30Rnd_556x45_G36)
+            QCLASS(AI_30Rnd_556x45_G36),
+            QCLASS(AI_100Rnd_556x45_BetaC)
         };
     };
 

--- a/addons/ammunition_ai/CfgMagazineWells.hpp
+++ b/addons/ammunition_ai/CfgMagazineWells.hpp
@@ -1,0 +1,321 @@
+class CfgMagazineWells {
+    // Handguns
+    class CBA_9x19_HiPower {
+        ADDON[] = {
+            QCLASS(AI_13Rnd_9x19_Browning)
+        };
+    };
+
+    class CBA_9x19_CZP09 {
+        ADDON[] = {
+            QCLASS(AI_17Rnd_9x19_Walther)
+        };
+    };
+
+    class CBA_9x19_CZ75_FULL {
+        ADDON[] = {
+            QCLASS(AI_18Rnd_9x19_CZ75)
+        };
+    };
+
+    class CBA_9x19_Walther {
+        ADDON[] = {
+            QCLASS(AI_17Rnd_9x19_Walther)
+        };
+    };
+
+    class CBA_9x19_Glock_Full {
+        ADDON[] = {
+            QCLASS(AI_17Rnd_9x19_Glock)
+        };
+    };
+
+    class CBA_9x19_P226 {
+        ADDON[] = {
+            QCLASS(AI_15Rnd_9x19_SIG)
+        };
+    };
+
+    class CBA_9x19_P228 {
+        ADDON[] = {
+            QCLASS(AI_15Rnd_9x19_SIG)
+        };
+    };
+
+    class CBA_9x19_M17 {
+        ADDON[] = {
+            QCLASS(AI_17Rnd_9x19_M17)
+        };
+    };
+
+    class CBA_9x19_M9 {
+        ADDON[] = {
+            QCLASS(AI_15Rnd_9x19_M9)
+        };
+    };
+
+    class CBA_9x19_P239 {
+        ADDON[] = {
+            QCLASS(AI_10Rnd_9x19_P239)
+        };
+    };
+
+    class CBA_45ACP_FNX45 {
+        ADDON[] = {
+            QCLASS(AI_11Rnd_45ACP_FNX)
+        };
+    };
+
+    class CBA_45ACP_MK23 {
+        ADDON[] = {
+            QCLASS(AI_12Rnd_45ACP_MK23)
+        };
+    };
+
+    class CBA_45ACP_1911 {
+        ADDON[] = {
+            QCLASS(AI_8Rnd_45ACP_1911)
+        };
+    };
+
+    // Rifle / SMG
+    class CBA_9x19_MP5 {
+        ADDON[] = {
+            QCLASS(AI_30Rnd_9x19)
+        };
+    };
+
+    class CLASS(9x19_MP5) {
+        ADDON[] = {
+            QCLASS(AI_30Rnd_9x19_MP5)
+        };
+    };
+
+    class CBA_9x19_ScorpionEvo3 {
+        ADDON[] = {
+            QCLASS(AI_30Rnd_9x19)
+        };
+    };
+
+    class CBA_9x19_PP19 {
+        ADDON[] = {
+            QCLASS(AI_64Rnd_9x19_Bizon)
+        };
+    };
+
+    class CBA_9x19_Vityaz {
+        ADDON[] = {
+            QCLASS(AI_30Rnd_9x19_Vityaz)
+        };
+    };
+
+    class CBA_45ACP_Glock_Full {
+        ADDON[] = {
+            QCLASS(AI_25Rnd_45ACP_Vector)
+        };
+    };
+
+    class CBA_46x30_MP7 {
+        ADDON[] = {
+            QCLASS(AI_40Rnd_46x30_MP7)
+        };
+    };
+
+    class CBA_545x39_AK {
+        ADDON[] = {
+            QCLASS(AI_30Rnd_545x39_AK),
+            QCLASS(AI_60Rnd_545x39_AK)
+        };
+    };
+
+    class CBA_545x39_Fort {
+        ADDON[] = {
+            QCLASS(AI_30Rnd_545x39_Fort)
+        };
+    };
+
+    class CBA_556x45_AK {
+        ADDON[] = {
+            QCLASS(AI_30Rnd_556x45_AK)
+        };
+    };
+
+    class CBA_556x45_G36 {
+        ADDON[] = {
+            QCLASS(AI_30Rnd_556x45_G36)
+        };
+    };
+
+    class CBA_556x45_FAMAS {
+        ADDON[] = {
+            QCLASS(AI_25Rnd_556x45_FAMAS)
+        };
+    };
+
+    class CBA_556x45_SG550 {
+        ADDON[] = {
+            QCLASS(AI_30Rnd_556x45_SIG)
+        };
+    };
+
+    class CBA_556x45_STANAG {
+        ADDON[] = {
+            QCLASS(AI_30Rnd_556x45_STANAG),
+            QCLASS(AI_60Rnd_556x45_Surefire),
+            QCLASS(AI_100Rnd_556x45_BetaC)
+        };
+    };
+
+    class CBA_556x45_STANAG_2D_XL {
+        ADDON[] = {
+            QCLASS(AI_150Rnd_556x45_Drum)
+        };
+    };
+
+    class CBA_556x45_STEYR {
+        ADDON[] = {
+            QCLASS(AI_30Rnd_556x45_AUG)
+        };
+    };
+
+    class 556x45_Velko {
+        ADDON[] = {
+            QCLASS(AI_35Rnd_556x45_R4)
+        };
+    };
+
+    class CBA_556x45_MINIMI {
+        ADDON[] = {
+            QCLASS(AI_200Rnd_556x45_Pouch),
+            QCLASS(AI_200Rnd_556x45_Box)
+        };
+    };
+
+    class CBA_57x28_P90 {
+        ADDON[] = {
+            QCLASS(AI_50Rnd_57x28)
+        };
+    };
+
+    class CBA_580x42_TYPE95 {
+        ADDON[] = {
+            QCLASS(AI_30Rnd_58x42)
+        };
+    };
+
+    class CBA_580x42_TYPE95_XL {
+        ADDON[] = {
+            QCLASS(AI_100Rnd_58x42)
+        };
+    };
+
+    class CBA_65x39_MX {
+        ADDON[] = {
+            QCLASS(AI_30Rnd_65x39_MX),
+            QCLASS(AI_30Rnd_65x39_MX_Black)
+        };
+    };
+
+    class CBA_65x39_MX_XL {
+        ADDON[] = {
+            QCLASS(AI_100Rnd_65x39_MX),
+            QCLASS(AI_100Rnd_65x39_MX_Black)
+        };
+    };
+
+    class CBA_65x39_MSBS {
+        ADDON[] = {
+            QCLASS(AI_30Rnd_65x39_GROT)
+        };
+    };
+
+    class CBA_65x39_Katiba {
+        ADDON[] = {
+            QCLASS(AI_30Rnd_65x39_Katiba)
+        };
+    };
+
+    class CBA_65x39_Mk200 {
+        ADDON[] = {
+            QCLASS(AI_200Rnd_65x39_Belt)
+        };
+    };
+
+    class CBA_65x39_QBU {
+        ADDON[] = {
+            QCLASS(AI_20Rnd_65x39)
+        };
+    };
+
+    class CBA_68SPC_STANAG {
+        ADDON[] = {
+            QCLASS(AI_30Rnd_68x43)
+        };
+    };
+
+    class CBA_762x39_AK {
+        ADDON[] = {
+            QCLASS(AI_30Rnd_762x39_AK)
+        };
+    };
+
+    class CBA_762x39_RPK {
+        ADDON[] = {
+            QCLASS(AI_75Rnd_762x39_Drum)
+        };
+    };
+
+    class CLASS(762x39_CZ) {
+        ADDON[] = {
+            QCLASS(AI_30Rnd_762x39_CZ807)
+        };
+    };
+
+    class CBA_762x51_AR10 {
+        ADDON[] = {
+            QCLASS(AI_20Rnd_762x51)
+        };
+    };
+
+    class CBA_762x51_FAL {
+        ADDON[] = {
+            QCLASS(AI_20Rnd_762x51_FAL)
+        };
+    };
+
+    class CBA_762x51_G3 {
+        ADDON[] = {
+            QCLASS(AI_20Rnd_762x51)
+        };
+    };
+
+    class CBA_762x51_SCAR {
+        ADDON[] = {
+            QCLASS(AI_20Rnd_762x51_SCARH)
+        };
+    };
+
+    class CBA_762x51_HK417 {
+        ADDON[] = {
+            QCLASS(AI_20Rnd_762x51)
+        };
+    };
+
+    class CBA_762x51_M14 {
+        ADDON[] = {
+            QCLASS(AI_20Rnd_762x51)
+        };
+    };
+
+    class CBA_762x51_SR25 {
+        ADDON[] = {
+            QCLASS(AI_20Rnd_762x51)
+        };
+    };
+
+    class CBA_762x51_LINKS {
+        ADDON[] = {
+            QCLASS(AI_100Rnd_762x51_Belt)
+        };
+    };
+};

--- a/addons/ammunition_ai/CfgMagazines.hpp
+++ b/addons/ammunition_ai/CfgMagazines.hpp
@@ -1,0 +1,422 @@
+class CfgMagazines {
+ /*
+  * All magazines here are scope = 1, will provide a list somewhere for usage in TAC Units.
+  * As with our other magazines these will utilise a shared pool.
+  * Magazine display names won't conform to our usual standard to differentiate easily in-game.
+  */
+
+    // 9mm
+    // Walther
+    class 16Rnd_9x21_Mag;
+    class CLASS(AI_17Rnd_9x19_Walther): 16Rnd_9x21_Mag {
+        MACRO_AI_MAGAZINE_HANDGUN
+        ammo = QCLASS(AI_9x19);
+        displayName = "Generic 9mm Walther Magazine";
+    };
+
+    // Browning
+    class CUP_13Rnd_9x19_Browning_HP;
+    class CLASS(AI_13Rnd_9x19_Browning): CUP_13Rnd_9x19_Browning_HP {
+        MACRO_AI_MAGAZINE_HANDGUN
+        ammo = QCLASS(AI_9x19);
+        displayName = "Generic 9mm Browning Magazine";
+    };
+
+    // CZ75
+    class CUP_18Rnd_9x19_Phantom;
+    class CLASS(AI_18Rnd_9x19_CZ75): CUP_18Rnd_9x19_Phantom {
+        MACRO_AI_MAGAZINE_HANDGUN
+        ammo = QCLASS(AI_9x19);
+        displayName = "Generic 9mm CZ75 Magazine";
+    };
+
+    // Glock
+    class CUP_17Rnd_9x19_glock17;
+    class CLASS(AI_17Rnd_9x19_Glock): CUP_17Rnd_9x19_glock17 {
+        MACRO_AI_MAGAZINE_HANDGUN
+        ammo = QCLASS(AI_9x19);
+        displayName = "Generic 9mm Glock Magazine";
+    };
+
+    /// SiG
+    class hlc_15Rnd_9x19_B_P226;
+    class CLASS(AI_15Rnd_9x19_SIG): hlc_15Rnd_9x19_B_P226 {
+        MACRO_AI_MAGAZINE_HANDGUN
+        ammo = QCLASS(AI_9x19);
+        displayName = "Generic 9mm SiG Magazine";
+    };
+
+    // M17
+    class CUP_17Rnd_9x19_M17_Black;
+    class CLASS(AI_17Rnd_9x19_M17): CUP_17Rnd_9x19_M17_Black {
+        MACRO_AI_MAGAZINE_HANDGUN
+        ammo = QCLASS(AI_9x19);
+        displayName = "Generic 9mm M17 Magazine";
+    };
+
+    // M9
+    class CUP_15Rnd_9x19_M9;
+    class CLASS(AI_15Rnd_9x19_M9): CUP_15Rnd_9x19_M9 {
+        MACRO_AI_MAGAZINE_HANDGUN
+        ammo = QCLASS(AI_9x19);
+        displayName = "Generic 9mm M9 Magazine";
+    };
+
+    // SiG P239
+    class hlc_10Rnd_9x19_B_P239;
+    class CLASS(AI_10Rnd_9x19_P239): hlc_10Rnd_9x19_B_P239 {
+        MACRO_AI_MAGAZINE_HANDGUN
+        ammo = QCLASS(AI_9x19);
+        displayName = "Generic 9mm P239 Magazine";
+    };
+
+    // Generic 9x19 SMG
+    class 30Rnd_9x21_Mag;
+    class CLASS(AI_30Rnd_9x19): 30Rnd_9x21_Mag {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_9x19);
+        displayName = "Generic 9mm Magazine";
+    };
+
+    // MP5
+    class CUP_30Rnd_9x19_MP5;
+    class CLASS(AI_30Rnd_9x19_MP5): CUP_30Rnd_9x19_MP5 {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_9x19);
+        displayName = "Generic MP5 Magazine";
+    };
+
+    // Vityaz
+    class CUP_30Rnd_9x19_Vityaz;
+    class CLASS(AI_30Rnd_9x19_Vityaz): CUP_30Rnd_9x19_Vityaz {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_9x19);
+        displayName = "Generic Vityaz Magazine";
+    };
+
+    // Bizon
+    class CUP_64Rnd_9x19_Bizon_M;
+    class CLASS(AI_64Rnd_9x19_Bizon): CUP_64Rnd_9x19_Bizon_M {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_9x19);
+        displayName = "Generic Bizon Magazine";
+    };
+
+    // .45ACP
+    // 1911
+    class CUP_7Rnd_45ACP_1911;
+    class CLASS(AI_8Rnd_45ACP_1911): CUP_7Rnd_45ACP_1911 {
+        MACRO_AI_MAGAZINE_HANDGUN
+        ammo = QCLASS(AI_45ACP);
+        displayName = "Generic .45ACP 1911 Magazine";
+    };
+
+    // FNX-45
+    class 11Rnd_45ACP_Mag;
+    class CLASS(AI_11Rnd_45ACP_FNX): 11Rnd_45ACP_Mag {
+        MACRO_AI_MAGAZINE_HANDGUN
+        ammo = QCLASS(AI_45ACP);
+        displayName = "Generic .45ACP FNX Magazine";
+    };
+
+    // MK23 SOCOM
+    class CUP_12Rnd_45ACP_mk23;
+    class CLASS(AI_12Rnd_45ACP_MK23): CUP_12Rnd_45ACP_mk23 {
+        MACRO_AI_MAGAZINE_HANDGUN
+        ammo = QCLASS(AI_45ACP);
+        displayName = "Generic .45ACP MK23 Magazine";
+    };
+
+    // Vector
+    class 30Rnd_45ACP_Mag_SMG_01;
+    class CLASS(AI_25Rnd_45ACP_Vector): 30Rnd_45ACP_Mag_SMG_01 {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_45ACP);
+        displayName = "Generic .45ACP Vector Magazine";
+    };
+
+    // 4.6x30
+    class CUP_40Rnd_46x30_MP7;
+    class CLASS(AI_40Rnd_46x30_MP7): CUP_40Rnd_46x30_MP7 {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_46x30);
+        displayName = "Generic 4.6x30 MP7 Magazine";
+    };
+
+    // 5.45x39
+    // Regular
+    class 30Rnd_545x39_Mag_F;
+    class CLASS(AI_30Rnd_545x39_AK): 30Rnd_545x39_Mag_F {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_545x39);
+        displayName = "Generic 5.45x39 AK Magazine";
+    };
+
+    // Fort
+    class CUP_30Rnd_545x39_Fort224_M;
+    class CLASS(AI_30Rnd_545x39_Fort): CUP_30Rnd_545x39_Fort224_M {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_545x39);
+        displayName = "Generic 5.45x39 Fort Magazine";
+    };
+
+    // Quadstack
+    class CUP_60Rnd_545x39_AK74M_M;
+    class CLASS(AI_60Rnd_545x39_AK): CUP_60Rnd_545x39_AK74M_M {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_545x39);
+        displayName = "Generic 5.45x39 AK Quadstack Magazine";
+    };
+
+    // 5.56x45
+    // STANAG
+    class 30Rnd_556x45_Stanag;
+    class CLASS(AI_30Rnd_556x45_STANAG): 30Rnd_556x45_Stanag {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_556x45);
+        displayName = "Generic 5.56x45 STANAG Magazine";
+    };
+
+    // AUG
+    class hlc_30Rnd_556x45_B_AUG;
+    class CLASS(AI_30Rnd_556x45_AUG): hlc_30Rnd_556x45_B_AUG {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_556x45);
+        displayName = "Generic 5.56x45 AUG Magazine";
+    };
+
+    // AK
+    class CUP_30Rnd_556x45_AK;
+    class CLASS(AI_30Rnd_556x45_AK): CUP_30Rnd_556x45_AK {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_556x45);
+        displayName = "Generic 5.56x45 AK Magazine";
+    };
+
+    // G36
+    class CUP_30Rnd_TE1_Green_Tracer_556x45_G36;
+    class CLASS(AI_30Rnd_556x45_G36): CUP_30Rnd_TE1_Green_Tracer_556x45_G36 {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_556x45);
+        displayName = "Generic 5.56x45 G36 Magazine";
+    };
+
+    // FAMAS
+    class CUP_25Rnd_556x45_Famas;
+    class CLASS(AI_25Rnd_556x45_FAMAS): CUP_25Rnd_556x45_Famas {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_556x45);
+        displayName = "Generic 5.56x45 FAMAS Magazine";
+    };
+
+    // R4
+    class 35Rnd_556x45_Velko_reload_tracer_yellow_lxWS;
+    class CLASS(AI_35Rnd_556x45_R4): 35Rnd_556x45_Velko_reload_tracer_yellow_lxWS {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_556x45);
+        displayName = "Generic 5.56x45 R4 Magazine";
+    };
+
+    // SG55X Series
+    class hlc_30Rnd_556x45_EPR_sg550;
+    class CLASS(AI_30Rnd_556x45_SIG): hlc_30Rnd_556x45_EPR_sg550 {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_556x45);
+        displayName = "Generic 5.56x45 SIG Magazine";
+    };
+
+    // Surefire
+    class CUP_60Rnd_556x45_SureFire;
+    class CLASS(AI_60Rnd_556x45_Surefire): CUP_60Rnd_556x45_SureFire {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_556x45);
+        displayName = "Generic 5.56x45 Surefire Magazine";
+    };
+
+    // Beta-C
+    class CUP_100Rnd_556x45_BetaCMag;
+    class CLASS(AI_100Rnd_556x45_BetaC): CUP_100Rnd_556x45_BetaCMag {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_556x45);
+        displayName = "Generic 5.56x45 Beta-C Magazine";
+    };
+
+    // Drum
+    class 150Rnd_556x45_Drum_Mag_F;
+    class CLASS(AI_150Rnd_556x45_Drum): 150Rnd_556x45_Drum_Mag_F {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_556x45);
+        displayName = "Generic 5.56x45 Drum Magazine";
+    };
+
+    // M249 Pouch
+    class CUP_200Rnd_TE4_Green_Tracer_556x45_M249_Pouch;
+    class CLASS(AI_200Rnd_556x45_Pouch): CUP_200Rnd_TE4_Green_Tracer_556x45_M249_Pouch {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_556x45);
+        displayName = "Generic 5.56x45 Pouch";
+    };
+
+    // Box
+    class 200Rnd_556x45_Box_F;
+    class CLASS(AI_200Rnd_556x45_Box): 200Rnd_556x45_Box_F {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_556x45);
+        displayName = "Generic 5.56x45 Box Magazine";
+    };
+
+    // 5.7x28
+    class 50Rnd_570x28_SMG_03;
+    class CLASS(AI_50Rnd_57x28): 50Rnd_570x28_SMG_03 {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_57x28);
+        displayName = "Generic 5.7x28 Magazine";
+    };
+
+    // 5.8x42
+    // QBZ
+    class 30Rnd_580x42_Mag_F;
+    class CLASS(AI_30Rnd_58x42): 30Rnd_580x42_Mag_F {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_58x42);
+        displayName = "Generic 5.8x42 Magazine";
+    };
+
+    // QBZ LSW
+    class 100Rnd_580x42_Mag_F;
+    class CLASS(AI_100Rnd_58x42): 100Rnd_580x42_Mag_F {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_58x42);
+        displayName = "Generic 5.8x42 Drum Magazine";
+    };
+
+    // 6.5x39
+    // MX
+    class 30Rnd_65x39_caseless_mag;
+    class CLASS(AI_30Rnd_65x39_MX): 30Rnd_65x39_caseless_mag {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_65x39);
+        displayName = "Generic 6.5x39 MX Magazine";
+    };
+
+    class 30Rnd_65x39_caseless_black_mag;
+    class CLASS(AI_30Rnd_65x39_MX_Black): 30Rnd_65x39_caseless_black_mag {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_65x39);
+        displayName = "Generic 6.5x39 MX Magazine";
+    };
+
+    // MX LSW
+    class 100Rnd_65x39_caseless_mag;
+    class CLASS(AI_100Rnd_65x39_MX): 100Rnd_65x39_caseless_mag {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_65x39);
+        displayName = "Generic 6.5x39 MX Magazine";
+    };
+
+    class 100Rnd_65x39_caseless_black_mag;
+    class CLASS(AI_100Rnd_65x39_MX_Black): 100Rnd_65x39_caseless_black_mag {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_65x39);
+        displayName = "Generic 6.5x39 MX Magazine";
+    };
+
+    // GROT
+    class 30Rnd_65x39_caseless_msbs_mag;
+    class CLASS(AI_30Rnd_65x39_GROT): 30Rnd_65x39_caseless_msbs_mag {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_65x39);
+        displayName = "Generic 6.5x39 GROT Magazine";
+    };
+
+    // Katiba / Type-115
+    class 30Rnd_65x39_caseless_green;
+    class CLASS(AI_30Rnd_65x39_Katiba): 30Rnd_65x39_caseless_green {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_65x39);
+        displayName = "Generic 6.5x39 Katiba Magazine";
+    };
+
+    // QBU
+    class 20Rnd_650x39_Cased_Mag_F;
+    class CLASS(AI_20Rnd_65x39): 20Rnd_650x39_Cased_Mag_F {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_65x39);
+        displayName = "Generic 6.5x39 QBU Magazine";
+    };
+
+    // Belt
+    class 200Rnd_65x39_cased_Box;
+    class CLASS(AI_200Rnd_65x39_Belt): 200Rnd_65x39_cased_Box {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_65x39);
+        displayName = "Generic 6.5x39 Belt";
+    };
+
+    // 6.8x43
+    // ACR
+    class CUP_30Rnd_680x43_Stanag;
+    class CLASS(AI_30Rnd_68x43): CUP_30Rnd_680x43_Stanag {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_68x43);
+        displayName = "Generic 6.8x43 Magazine";
+    };
+
+    // 7.62x39
+    // AK
+    class 30Rnd_762x39_Mag_F;
+    class CLASS(AI_30Rnd_762x39_AK): 30Rnd_762x39_Mag_F {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_762x39);
+        displayName = "Generic 7.62x39 Magazine";
+    };
+
+    // CZ807
+    class CUP_30Rnd_762x39_CZ807;
+    class CLASS(AI_30Rnd_762x39_CZ807): CUP_30Rnd_762x39_CZ807 {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_762x39);
+        displayName = "Generic 7.62x39 Magazine";
+    };
+
+    // Drum
+    class 75rnd_762x39_AK12_Mag_F;
+    class CLASS(AI_75Rnd_762x39_Drum): 75rnd_762x39_AK12_Mag_F {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_762x39);
+        displayName = "Generic 7.62x39 Drum";
+    };
+
+    // 7.62x51
+    // Generic DMR
+    class 20Rnd_762x51_Mag;
+    class CLASS(AI_20Rnd_762x51): 20Rnd_762x51_Mag {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_762x51);
+        displayName = "Generic 7.62x51 Magazine";
+    };
+
+    // FAL
+    class CUP_20Rnd_762x51_FNFAL_M;
+    class CLASS(AI_20Rnd_762x51_FAL): CUP_20Rnd_762x51_FNFAL_M {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_762x51);
+        displayName = "Generic 7.62x51 FAL Magazine";
+    };
+
+    // SCAR-H
+    class CUP_20Rnd_762x51_B_SCAR_bkl;
+    class CLASS(AI_20Rnd_762x51_SCARH): CUP_20Rnd_762x51_B_SCAR_bkl {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_762x51);
+        displayName = "Generic 7.62x51 SCAR-H Magazine";
+    };
+
+    // Belt
+    class hlc_100Rnd_762x51_B_M60E4;
+    class CLASS(AI_100Rnd_762x51_Belt): hlc_100Rnd_762x51_B_M60E4 {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_762x51);
+        displayName = "Generic 7.62x51 Belt";
+    };
+};

--- a/addons/ammunition_ai/CfgMagazines.hpp
+++ b/addons/ammunition_ai/CfgMagazines.hpp
@@ -86,6 +86,22 @@ class CfgMagazines {
         displayName = "Generic MP5 Magazine";
     };
 
+    // TEC9
+    class CUP_32Rnd_9x19_TEC9;
+    class CLASS(AI_32Rnd_9x19_TEC9): CUP_32Rnd_9x19_TEC9 {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_9x19);
+        displayName = "Generic TEC9 Magazine";
+    };
+
+    // UZI
+    class CUP_32Rnd_9x19_UZI_M;
+    class CLASS(AI_32Rnd_9x19_UZI): CUP_32Rnd_9x19_UZI_M {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_9x19);
+        displayName = "Generic UZI Magazine";
+    };
+
     // Vityaz
     class CUP_30Rnd_9x19_Vityaz;
     class CLASS(AI_30Rnd_9x19_Vityaz): CUP_30Rnd_9x19_Vityaz {
@@ -125,6 +141,14 @@ class CfgMagazines {
         MACRO_AI_MAGAZINE_HANDGUN
         ammo = QCLASS(AI_45ACP);
         displayName = "Generic .45ACP MK23 Magazine";
+    };
+
+    // MAC-10
+    class CUP_30Rnd_45ACP_MAC10_M;
+    class CLASS(AI_30Rnd_45ACP_MAC10): CUP_30Rnd_45ACP_MAC10_M {
+        MACRO_AI_MAGAZINE
+        ammo = QCLASS(AI_45ACP);
+        displayName = "Generic .45ACP MAC10 Magazine";
     };
 
     // Vector

--- a/addons/ammunition_ai/README.md
+++ b/addons/ammunition_ai/README.md
@@ -1,6 +1,8 @@
 # Ammunition AI
 
-Magazines designed specifically for AI only.
+Magazines that utilise a different tracer colour to Theseus with slightly improved performance.
+
+If a magazine you're looking for is not listed, you can request for it to be added or just use any other.
 
 AI Magazine | Original Magazine
 If the right hand side classname fits the gun, the one on the left will too.

--- a/addons/ammunition_ai/README.md
+++ b/addons/ammunition_ai/README.md
@@ -1,0 +1,93 @@
+# Ammunition AI
+
+Magazines designed specifically for AI only.
+
+AI Magazine | Original Magazine
+If the right hand side classname fits the gun, the one on the left will too.
+
+## Handgun Magazines
+| AI Magazine                    | Original Classname |
+|:------------                   |------------------:|
+|`tacgt_AI_17Rnd_9x19_Walther`   | 16Rnd_9x21_Mag|
+|`tacgt_AI_13Rnd_9x19_Browning`  | CUP_13Rnd_9x19_Browning_HP|
+|`tacgt_AI_18Rnd_9x19_CZ75`      | CUP_18Rnd_9x19_Phantom|
+|`tacgt_AI_17Rnd_9x19_Glock`     | CUP_17Rnd_9x19_glock17|
+|`tacgt_AI_15Rnd_9x19_SIG`       | hlc_15Rnd_9x19_B_P226|
+|`tacgt_AI_17Rnd_9x19_M17`       | CUP_17Rnd_9x19_M17_Black|
+|`tacgt_AI_15Rnd_9x19_M9`        | CUP_15Rnd_9x19_M9|
+|`tacgt_AI_10Rnd_9x19_P239`      | hlc_10Rnd_9x19_B_P239|
+|`tacgt_AI_8Rnd_45ACP_1911`      | CUP_7Rnd_45ACP_1911|
+|`tacgt_AI_11Rnd_45ACP_FNX`      | 11Rnd_45ACP_Mag|
+|`tacgt_AI_12Rnd_45ACP_MK23`     | CUP_12Rnd_45ACP_mk23|
+
+---
+
+## Sub-Machine Gun Magazines
+| AI Magazine                    | Original Classname |
+|:------------                   |------------------:|
+|`tacgt_AI_30Rnd_9x19_MP5`       | CUP_30Rnd_9x19_MP5|
+|`tacgt_AI_30Rnd_9x19`           | 30Rnd_9x21_Mag|
+|`tacgt_AI_32Rnd_9x19_TEC9`      | CUP_32Rnd_9x19_TEC9|
+|`tacgt_AI_32Rnd_9x19_UZI`       | CUP_32Rnd_9x19_UZI_M|
+|`tacgt_AI_30Rnd_9x19_Vityaz`    | CUP_30Rnd_9x19_Vityaz|
+|`tacgt_AI_64Rnd_9x19_Bizon`     | CUP_64Rnd_9x19_Bizon_M|
+|`tacgt_AI_30Rnd_45ACP_MAC10`    | CUP_30Rnd_45ACP_MAC10_M|
+|`tacgt_AI_25Rnd_45ACP_Vector`   | 30Rnd_45ACP_Mag_SMG_01|
+|`tacgt_AI_40Rnd_46x30_MP7`      | CUP_40Rnd_46x30_MP7|
+|`tacgt_AI_50Rnd_57x28`          | 50Rnd_570x28_SMG_03|
+
+---
+
+## Assault Rifle Magazines
+| AI Magazine                    | Original Classname |
+|:------------                   |------------------:|
+|`tacgt_AI_30Rnd_545x39_AK`      | 30Rnd_545x39_Mag_F|
+|`tacgt_AI_30Rnd_545x39_Fort`    | CUP_30Rnd_545x39_Fort224_M|
+|`tacgt_AI_60Rnd_545x39_AK`      | CUP_60Rnd_545x39_AK74M_M|
+|`tacgt_AI_30Rnd_556x45_STANAG`  | 30Rnd_556x45_Stanag|
+|`tacgt_AI_30Rnd_556x45_AUG`     | hlc_30Rnd_556x45_B_AUG|
+|`tacgt_AI_30Rnd_556x45_AK`      | CUP_30Rnd_556x45_AK|
+|`tacgt_AI_30Rnd_556x45_G36`     | CUP_30Rnd_TE1_Green_Tracer_556x45_G36|
+|`tacgt_AI_25Rnd_556x45_FAMAS`   | CUP_25Rnd_556x45_Famas|
+|`tacgt_AI_35Rnd_556x45_R4`      | 35Rnd_556x45_Velko_reload_tracer_yellow_lxWS|
+|`tacgt_AI_30Rnd_556x45_SIG`     | hlc_30Rnd_556x45_EPR_sg550|
+|`tacgt_AI_60Rnd_556x45_Surefire`| CUP_60Rnd_556x45_SureFire|
+|`tacgt_AI_100Rnd_556x45_BetaC`  | CUP_100Rnd_556x45_BetaCMag|
+|`tacgt_AI_150Rnd_556x45_Drum`   | 150Rnd_556x45_Drum_Mag_F|
+|`tacgt_AI_30Rnd_58x42`          | 30Rnd_580x42_Mag_F|
+|`tacgt_AI_30Rnd_65x39_MX`       | 30Rnd_65x39_caseless_mag|
+|`tacgt_AI_30Rnd_65x39_MX_Black` | 30Rnd_65x39_caseless_black_mag|
+|`tacgt_AI_30Rnd_65x39_GROT`     | 30Rnd_65x39_caseless_msbs_mag|
+|`tacgt_AI_30Rnd_65x39_Katiba`   | 30Rnd_65x39_caseless_green|
+|`tacgt_AI_30Rnd_68x43`          | CUP_30Rnd_680x43_Stanag|
+|`tacgt_AI_30Rnd_762x39_AK`      | 30Rnd_762x39_Mag_F|
+|`tacgt_AI_30Rnd_762x39_CZ807`   | CUP_30Rnd_762x39_CZ807|
+
+---
+
+## Light Machine-Gun Magazines
+| AI Magazine                    | Original Classname |
+|:------------                   |------------------:|
+|`tacgt_AI_200Rnd_556x45_Pouch`  | CUP_200Rnd_TE4_Green_Tracer_556x45_M249_Pouch|
+|`tacgt_AI_200Rnd_556x45_Box`    | 200Rnd_556x45_Box_F|
+|`tacgt_AI_100Rnd_58x42`         | 100Rnd_580x42_Mag_F|
+|`tacgt_AI_100Rnd_65x39_MX`      | 100Rnd_65x39_caseless_mag|
+|`tacgt_AI_100Rnd_65x39_MX_Black`| 100Rnd_65x39_caseless_black_mag|
+|`tacgt_AI_200Rnd_65x39_Belt`    | 200Rnd_65x39_cased_Box|
+|`tacgt_AI_75Rnd_762x39_Drum`    | 75rnd_762x39_AK12_Mag_F|
+|`tacgt_AI_100Rnd_762x51_Belt`   | hlc_100Rnd_762x51_B_M60E4|
+
+---
+
+## Battle Rifles
+| AI Magazine                    | Original Classname |
+|:------------                   |------------------:|
+|`tacgt_AI_20Rnd_762x51_FAL`     | CUP_20Rnd_762x51_FNFAL_M|
+|`tacgt_AI_20Rnd_762x51_SCARH`   | CUP_20Rnd_762x51_B_SCAR_bkl|
+
+
+## Marksman Rifles
+| AI Magazine                    | Original Classname |
+|:------------                   |------------------:|
+|`tacgt_AI_20Rnd_65x39`          | 20Rnd_650x39_Cased_Mag_F|
+|`tacgt_AI_20Rnd_762x51`         | 20Rnd_762x51_Mag|

--- a/addons/ammunition_ai/config.cpp
+++ b/addons/ammunition_ai/config.cpp
@@ -1,0 +1,19 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"tacgt_ammunition"};
+        author = ECSTRING(main,Authors);
+        authors[] = {"Mike"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgAmmo.hpp"
+#include "CfgMagazines.hpp"
+#include "CfgMagazineWells.hpp"

--- a/addons/ammunition_ai/script_component.hpp
+++ b/addons/ammunition_ai/script_component.hpp
@@ -1,0 +1,24 @@
+#define COMPONENT ammunitionai
+#define COMPONENT_BEAUTIFIED Ammunition AI
+#include "\x\tacgt\addons\main\script_mod.hpp"
+#include "\x\tacgt\addons\main\script_macros.hpp"
+
+#define MACRO_TRACERS \
+    model = "\A3\Weapons_f\Data\bullettracer\tracer_Red"; \
+    tracerEndTime = 1; \
+    tracerScale = 0.5; \
+    tracerstartTime = 0.05;
+
+#define MACRO_AI_MAGAZINE \
+    scope = 1; \
+    scopeArsenal = 1; \
+    author = ECSTRING(main,Author); \
+    descriptionShort = ""; \
+    tracerEvery = 5;
+
+#define MACRO_AI_MAGAZINE_HANDGUN \
+    scope = 1; \
+    scopeArsenal = 1; \
+    author = ECSTRING(main,Author); \
+    descriptionShort = ""; \
+    lastRoundsTracer = 2;


### PR DESCRIPTION
Intended to be used for TAC Units, slightly improved ammo, different tracers.
Works with normal weapons but can't be stashed.