### PR TITLE
Ammunition - NiArms Fix

### DIFF
--- a/addons/ammunition/CfgAmmo.hpp
+++ b/addons/ammunition/CfgAmmo.hpp
@@ -20,7 +20,7 @@ class CfgAmmo {
     class B_762x39_Ball_F; // 7.62x39
     class B_762x51_Ball; // 7.62x51
     class B_762x54_Ball; // 7.62x54R
-    class HLC_300Blackout_RNBT; // .300 Blackout Subsonic
+    class HLC_300Blackout_Ball; // .300 Blackout Ball (Formerly subsonic)
     class CUP_B_9x39_SP5; // 9x39
 
     // 12G
@@ -288,8 +288,8 @@ class CfgAmmo {
     };
 
 
-    // .300AAC - Subsonic
-    class CLASS(300AAC_Ball): HLC_300Blackout_RNBT {
+    // .300AAC - Not subsonic anymore
+    class CLASS(300AAC_Ball): HLC_300Blackout_Ball {
         aiAmmoUsageFlags = "64 + 128";
         caliber = 0.19;
         hit = 12;

--- a/addons/ammunition/CfgAmmo.hpp
+++ b/addons/ammunition/CfgAmmo.hpp
@@ -288,7 +288,7 @@ class CfgAmmo {
     };
 
 
-    // .300AAC - Not subsonic anymore
+    // .300AAC - Not subsonic anymore - Ridiculous drop at 400m
     class CLASS(300AAC_Ball): HLC_300Blackout_Ball {
         aiAmmoUsageFlags = "64 + 128";
         caliber = 0.19;

--- a/addons/ammunition/CfgMagazines.hpp
+++ b/addons/ammunition/CfgMagazines.hpp
@@ -48,7 +48,7 @@ class CfgMagazines {
     class hlc_100Rnd_762x51_B_M60E4;
     class 150Rnd_762x54_Box;
     class 10Rnd_762x54_Mag;
-    class hlc_29rnd_300BLK_STANAG_T;
+    class hlc_29rnd_300BLK_STANAG;
     class CUP_30Rnd_9x39_SP5_VIKHR_M;
     class 35Rnd_556x45_Velko_reload_tracer_yellow_lxWS;
     class 8Rnd_12Gauge_AA40_Pellets_lxWS;

--- a/addons/ammunition/CfgMagazines.hpp
+++ b/addons/ammunition/CfgMagazines.hpp
@@ -48,7 +48,7 @@ class CfgMagazines {
     class hlc_100Rnd_762x51_B_M60E4;
     class 150Rnd_762x54_Box;
     class 10Rnd_762x54_Mag;
-    class 29rnd_300BLK_STANAG_T;
+    class hlc_29rnd_300BLK_STANAG_T;
     class CUP_30Rnd_9x39_SP5_VIKHR_M;
     class 35Rnd_556x45_Velko_reload_tracer_yellow_lxWS;
     class 8Rnd_12Gauge_AA40_Pellets_lxWS;

--- a/addons/ammunition/magazines/300Blackout.hpp
+++ b/addons/ammunition/magazines/300Blackout.hpp
@@ -1,4 +1,4 @@
-class CLASS(30Rnd_300AAC_Ball): hlc_29rnd_300BLK_STANAG_T {
+class CLASS(30Rnd_300AAC_Ball): hlc_29rnd_300BLK_STANAG {
     MACRO_SCOPE
     ammo = QCLASS(300AAC_Ball);
     displayName = ".300AAC 30Rnd (Ball)";

--- a/addons/ammunition/magazines/300Blackout.hpp
+++ b/addons/ammunition/magazines/300Blackout.hpp
@@ -1,4 +1,4 @@
-class CLASS(30Rnd_300AAC_Ball): 29rnd_300BLK_STANAG_T {
+class CLASS(30Rnd_300AAC_Ball): hlc_29rnd_300BLK_STANAG_T {
     MACRO_SCOPE
     ammo = QCLASS(300AAC_Ball);
     displayName = ".300AAC 30Rnd (Ball)";


### PR DESCRIPTION
- Fix required for next NiArms version.

- Converts 300 Blackout from subsonic to ball.
- Changes parent mag because it wouldn't overwrite tracer values for some reason.