### PR TITLE
HLC Tweaks - Fix missing sound shader

### DIFF
--- a/addons/hlc_tweaks/CfgSoundShaders.hpp
+++ b/addons/hlc_tweaks/CfgSoundShaders.hpp
@@ -1,0 +1,13 @@
+class CfgSoundShaders {
+    class nia_p2269mm_closeShot_SoundShader {
+        range = 20;
+        rangeCurve[] = {
+            {0, 1.5},
+            {20, 0}
+        };
+        volume = "1.5*(1-interior)";
+        samples[] = {
+            {"hlc_wp_p226\snd\p226_close", 1}
+        };
+    };
+};

--- a/addons/hlc_tweaks/config.cpp
+++ b/addons/hlc_tweaks/config.cpp
@@ -7,7 +7,7 @@ class CfgPatches {
         weapons[] = {};
         magazines[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"tacgt_main", "hlcweapons_core"};
+        requiredAddons[] = {"tacgt_main", "hlcweapons_core", "niaweapons_226"};
         author = ECSTRING(main,Authors);
         authors[] = {"Mike"};
         url = ECSTRING(main,URL);
@@ -16,3 +16,4 @@ class CfgPatches {
 };
 
 #include "CfgWeapons.hpp"
+#include "CfgSoundShaders.hpp"


### PR DESCRIPTION
- Readds the missing soundshader.

There's a bunch of new ones being used, but the old ones are still referenced in `silencedShot` and this is the only one missing, the others still have the old ones.