### PR TITLE
Weapons - Remove Bipods from Vanilla MGs

### DIFF
--- a/addons/weapons/CfgWeapons.hpp
+++ b/addons/weapons/CfgWeapons.hpp
@@ -1,4 +1,5 @@
 class CfgWeapons {
+    #include "vanilla_overwrites.hpp"
     // Chiappa Rhino
     class Pistol_Base_F;
     class hgun_Pistol_heavy_02_F: Pistol_Base_F {

--- a/addons/weapons/vanilla_overwrites.hpp
+++ b/addons/weapons/vanilla_overwrites.hpp
@@ -1,0 +1,104 @@
+class arifle_MX_Base_F;
+class arifle_MX_SW_F: arifle_MX_Base_F {
+    class LinkedItems {
+        class LinkedItemsUnder {
+            slot = "UnderBarrelSlot";
+            item = "";
+        };
+    };
+};
+
+class arifle_MX_SW_Black_F: arifle_MX_SW_F {
+    class LinkedItems {
+        class LinkedItemsUnder {
+            slot = "UnderBarrelSlot";
+            item = "";
+        };
+    };
+};
+
+class arifle_MX_SW_khk_F: arifle_MX_SW_Black_F {
+    class LinkedItems {
+        class LinkedItemsUnder {
+            slot = "UnderBarrelSlot";
+            item = "";
+        };
+    };
+};
+
+class arifle_SPAR_02_base_F;
+class arifle_SPAR_02_blk_F: arifle_SPAR_02_base_F {
+    class LinkedItems {
+        class LinkedItemsUnder {
+            slot = "UnderBarrelSlot";
+            item = "";
+        };
+    };
+};
+
+class arifle_SPAR_02_khk_F: arifle_SPAR_02_base_F {
+    class LinkedItems {
+        class LinkedItemsUnder {
+            slot = "UnderBarrelSlot";
+            item = "";
+        };
+    };
+};
+
+class arifle_SPAR_02_snd_F: arifle_SPAR_02_base_F {
+    class LinkedItems {
+        class LinkedItemsUnder {
+            slot = "UnderBarrelSlot";
+            item = "";
+        };
+    };
+};
+
+
+class Rifle_Long_Base_F;
+class MMG_01_base_F: Rifle_Long_Base_F {
+    class LinkedItems {
+        class LinkedItemsUnder {
+            slot = "UnderBarrelSlot";
+            item = "";
+        };
+    };
+};
+
+class MMG_01_hex_F;
+class MMG_01_tan_F: MMG_01_hex_F {
+    class LinkedItems {
+        class LinkedItemsUnder {
+            slot = "UnderBarrelSlot";
+            item = "";
+        };
+    };
+};
+
+class MMG_02_base_F: Rifle_Long_Base_F {
+    class LinkedItems {
+        class LinkedItemsUnder {
+            slot = "UnderBarrelSlot";
+            item = "";
+        };
+    };
+};
+
+class MMG_02_camo_F;
+class MMG_02_black_F: MMG_02_camo_F {
+    class LinkedItems {
+        class LinkedItemsUnder {
+            slot = "UnderBarrelSlot";
+            item = "";
+        };
+    };
+};
+
+class MMG_02_sand_F: MMG_02_camo_F {
+    class LinkedItems {
+        class LinkedItemsUnder {
+            slot = "UnderBarrelSlot";
+            item = "";
+        };
+    };
+};


### PR DESCRIPTION
Vanilla machineguns automatically come with bipods. Doesn't really work for a system where you buy them.