### PR TITLE
Ammunition - Add `cartridge` property to ammunition

### DIFF
--- a/addons/ammunition/CfgAmmo.hpp
+++ b/addons/ammunition/CfgAmmo.hpp
@@ -57,6 +57,7 @@ class CfgAmmo {
         caliber = 0.525;
         submunitionConeType[] = {"random", 12};
         triggerTime = 0.008;
+        cartridge = "FxCartridge_slug";
         submunitionAmmo = QCLASS(12g_Pellets_Submunition_Deploy);
         submunitionConeAngle = 0.81;
     };
@@ -66,8 +67,9 @@ class CfgAmmo {
     class CLASS(9x19_Ball): B_9x21_Ball_Tracer_Yellow {
         aiAmmoUsageFlags = "64 + 128";
         caliber = 0.1;
+        cartridge = "FxCartridge_9mm";
         hit = 8;
-        MACRO_TRACERS
+        MACRO_TRACERS;
     };
     class CLASS(9x19_EPR): CLASS(9x19_Ball) {
         caliber = 0.9;
@@ -83,7 +85,7 @@ class CfgAmmo {
         aiAmmoUsageFlags = "64 + 128";
         caliber = 0.3;
         hit = 10;
-        MACRO_TRACERS
+        MACRO_TRACERS;
     };
     class CLASS(545x39_EPR): CLASS(545x39_Ball) {
         caliber = 1;
@@ -98,8 +100,9 @@ class CfgAmmo {
     class CLASS(45ACP_Ball): B_45ACP_Ball {
         aiAmmoUsageFlags = "64 + 128";
         caliber = 0.15;
+        cartridge = "FxCartridge_9mm";
         hit = 11;
-        MACRO_TRACERS
+        MACRO_TRACERS;
     };
     class CLASS(45ACP_EPR): CLASS(45ACP_Ball) {
         caliber = 0.85;
@@ -126,7 +129,7 @@ class CfgAmmo {
         aiAmmoUsageFlags = "64 + 128";
         caliber = 0.25;
         hit = 10;
-        MACRO_TRACERS
+        MACRO_TRACERS;
     };
     class CLASS(58x42_EPR): CLASS(58x42_Ball) {
         caliber = 1.35;
@@ -143,7 +146,7 @@ class CfgAmmo {
         aiAmmoUsageFlags = "64 + 128";
         caliber = 0.4;
         hit = 11;
-        MACRO_TRACERS
+        MACRO_TRACERS;
     };
     class CLASS(556x45_EPR): CLASS(556x45_Ball) {
         hit = 12;
@@ -163,8 +166,9 @@ class CfgAmmo {
     class CLASS(65x39_Ball): B_65x39_Caseless {
         aiAmmoUsageFlags = "64 + 128";
         caliber = 0.35;
+        cartridge = "FxCartridge_65";
         hit = 10.8;
-        MACRO_TRACERS
+        MACRO_TRACERS;
     };
     class CLASS(65x39_EPR): CLASS(65x39_Ball) {
         caliber = 1.6;
@@ -196,7 +200,7 @@ class CfgAmmo {
         aiAmmoUsageFlags = "64 + 128";
         caliber = 0.25;
         hit = 11.3;
-        MACRO_TRACERS
+        MACRO_TRACERS;
     };
     class CLASS(762x39_EPR): CLASS(762x39_Ball) {
         caliber = 1.55;
@@ -212,7 +216,7 @@ class CfgAmmo {
         aiAmmoUsageFlags = "64 + 128";
         caliber = 0.28;
         hit = 12.8;
-        MACRO_TRACERS
+        MACRO_TRACERS;
     };
     class CLASS(762x51_EPR): CLASS(762x51_Ball) {
         caliber = 1.85;
@@ -246,7 +250,7 @@ class CfgAmmo {
         aiAmmoUsageFlags = "64 + 128";
         caliber = 0.33;
         hit = 13;
-        MACRO_TRACERS
+        MACRO_TRACERS;
     };
     class CLASS(762x54r_EPR): CLASS(762x54r_Ball) {
         caliber = 2;

--- a/addons/ammunition/bi/magazines/12g.hpp
+++ b/addons/ammunition/bi/magazines/12g.hpp
@@ -1,5 +1,5 @@
 class CLASS(2Rnd_P_000): 2Rnd_12Gauge_Pellets {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     displayName = "2Rnd (Magnum)";
     displayNameShort = "#00 Magnum";
     descriptionShort = "#00 Magnum Shells";
@@ -23,7 +23,7 @@ class CLASS(8Rnd_P_000): CA_Magazine {
 };
 
 class CLASS(8Rnd_S_AP20): CA_Magazine {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(S_12G_AP20);
     displayName = "8Rnd M1014 (Slug)";
     displayNameShort = "AP-20";
@@ -68,7 +68,7 @@ class CLASS(6Rnd_Smoke_M1014): CLASS(8Rnd_Smoke_M1014) {
 
 // 6Rnd MSBS GROT
 class CLASS(6Rnd_P_UGL): 6Rnd_12Gauge_Pellets {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(P_12G_000);
     displayName = "6Rnd MSBS (Magnum)";
     displayNameShort = "#00 Magnum";
@@ -76,7 +76,7 @@ class CLASS(6Rnd_P_UGL): 6Rnd_12Gauge_Pellets {
 };
 
 class CLASS(6Rnd_S_UGL): 6Rnd_12Gauge_Slug {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(S_12G_AP20);
     displayName = "6Rnd MSBS (Slug)";
     displayNameShort = "AP-20";

--- a/addons/ammunition/bi/magazines/45ACP.hpp
+++ b/addons/ammunition/bi/magazines/45ACP.hpp
@@ -1,7 +1,7 @@
 // .45ACP FNX-45
 class 11Rnd_45ACP_Mag;
 class CLASS(15Rnd_45ACP_FNX45_Ball): 11Rnd_45ACP_Mag {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(45ACP_Ball);
     descriptionShort = ".45ACP Ball Reload Tracer";
     displayName = ".45ACP 15Rnd FNX-45 (Ball)";
@@ -10,7 +10,7 @@ class CLASS(15Rnd_45ACP_FNX45_Ball): 11Rnd_45ACP_Mag {
 
 // .45ACP SMG
 class CLASS(25Rnd_45ACP_Ball): 30Rnd_45ACP_Mag_SMG_01 {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(45ACP_Ball);
     displayName = ".45ACP 25Rnd (Ball)";
     displayNameShort = "Ball";

--- a/addons/ammunition/bi/magazines/545x39.hpp
+++ b/addons/ammunition/bi/magazines/545x39.hpp
@@ -1,7 +1,7 @@
 // 5.45x39mm (Using the nice looking AK-12 Mags)
 class CLASS(30Rnd_545x39_Ball): 30Rnd_545x39_Mag_F {
-    MACRO_SCOPE
-    MACRO_AK12_MAGAZINE_TAN
+    MACRO_SCOPE;
+    MACRO_AK12_MAGAZINE_TAN;
     ammo = QCLASS(545x39_Ball);
     displayName = "5.45mm 30Rnd Tan (Ball)";
     displayNameShort = "Ball";
@@ -30,19 +30,19 @@ class CLASS(30Rnd_545x39_AP): CLASS(30Rnd_545x39_EPR) {
 
 // 5.45x39mm Black
 class CLASS(30Rnd_545x39_Ball_Black): CLASS(30Rnd_545x39_Ball) {
-    MACRO_AK12_MAGAZINE_BLACK
+    MACRO_AK12_MAGAZINE_BLACK;
     displayName = "5.45mm 30Rnd Black (Ball)";
 };
 class CLASS(30Rnd_545x39_Ball_Tracer_Black): CLASS(30Rnd_545x39_Ball_Tracer) {
-    MACRO_AK12_MAGAZINE_BLACK
+    MACRO_AK12_MAGAZINE_BLACK;
     displayName = "5.45mm 30Rnd Black [T] (Ball)";
 };
 
 class CLASS(30Rnd_545x39_EPR_Black): CLASS(30Rnd_545x39_EPR) {
-    MACRO_AK12_MAGAZINE_BLACK
+    MACRO_AK12_MAGAZINE_BLACK;
     displayName = "5.45mm 30Rnd Black (EPR)";
 };
 class CLASS(30Rnd_545x39_AP_Black): CLASS(30Rnd_545x39_AP) {
-    MACRO_AK12_MAGAZINE_BLACK
+    MACRO_AK12_MAGAZINE_BLACK;
     displayName = "5.45mm 30Rnd Black (AP)";
 };

--- a/addons/ammunition/bi/magazines/556x45.hpp
+++ b/addons/ammunition/bi/magazines/556x45.hpp
@@ -1,6 +1,6 @@
 // 5.56x45mm Belt
 class CLASS(200Rnd_556x45_Ball_Belt): 200Rnd_556x45_Box_F {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(556x45_Ball);
     displayName = "5.56mm 200Rnd Belt [TE4] (Ball)";
     displayNameShort = "Ball TE4";
@@ -23,7 +23,7 @@ class CLASS(200Rnd_556x45_EPR_Belt): CLASS(200Rnd_556x45_Ball_Belt) {
 
 // 5.56x45mm Drum 150
 class CLASS(150Rnd_556x45_Ball_Drum): 150Rnd_556x45_Drum_Mag_F {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(556x45_Ball);
     displayName = "5.56mm 150Rnd Drum [TE4] (Ball)";
     displayNameShort = "Ball TE4";

--- a/addons/ammunition/bi/magazines/57x28.hpp
+++ b/addons/ammunition/bi/magazines/57x28.hpp
@@ -1,6 +1,6 @@
 // 5.7x28mm - Only one because all 5.7 Ammo is considered AP.
 class CLASS(50Rnd_57x28_Ball): 50Rnd_570x28_SMG_03 {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(57x28_Ball);
     displayName = "5.7mm 50Rnd (AP)";
     displayNameShort = "AP";

--- a/addons/ammunition/bi/magazines/58x42.hpp
+++ b/addons/ammunition/bi/magazines/58x42.hpp
@@ -1,6 +1,6 @@
 // 5.8x42mm
 class CLASS(30Rnd_58x42_Ball): 30Rnd_580x42_Mag_F {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(58x42_Ball);
     displayName = "5.8mm 30Rnd (Ball)";
     displayNameShort = "Ball";
@@ -29,7 +29,7 @@ class CLASS(30Rnd_58x42_AP): CLASS(30Rnd_58x42_EPR) {
 
 // 5.8x42mm Drum
 class CLASS(100Rnd_58x42_Ball): 100Rnd_580x42_Mag_F {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(58x42_Ball);
     displayName = "5.8mm 100Rnd [TE4] (Ball)";
     displayNameShort = "Ball TE4";

--- a/addons/ammunition/bi/magazines/65x39.hpp
+++ b/addons/ammunition/bi/magazines/65x39.hpp
@@ -1,6 +1,6 @@
 // 6.5x39mm (MX, Sand)
 class CLASS(30Rnd_65x39_Ball_MX_Sand): 30Rnd_65x39_caseless_mag {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(65x39_Ball);
     displayName = "6.5mm 30Rnd MX Sand (Ball)";
     displayNameShort = "Ball";
@@ -28,25 +28,25 @@ class CLASS(30Rnd_65x39_AP_MX_Sand): CLASS(30Rnd_65x39_EPR_MX_Sand) {
 
 // 6.5x39mm (MX, Black)
 class CLASS(30Rnd_65x39_Ball_MX_Black): CLASS(30Rnd_65x39_Ball_MX_Sand) {
-    MACRO_65_MAGAZINE_MX_Black
+    MACRO_65_MAGAZINE_MX_Black;
     displayName = "6.5mm 30Rnd MX Black (Ball)";
 };
 class CLASS(30Rnd_65x39_Ball_Tracer_MX_Black): CLASS(30Rnd_65x39_Ball_Tracer_MX_Sand) {
-    MACRO_65_MAGAZINE_MX_Black
+    MACRO_65_MAGAZINE_MX_Black;
     displayName = "6.5mm 30Rnd MX Black [T] (Ball)";
 };
 class CLASS(30Rnd_65x39_EPR_MX_Black): CLASS(30Rnd_65x39_EPR_MX_Sand) {
-    MACRO_65_MAGAZINE_MX_Black
+    MACRO_65_MAGAZINE_MX_Black;
     displayName = "6.5mm 30Rnd MX Black (EPR)";
 };
 class CLASS(30Rnd_65x39_AP_MX_Black): CLASS(30Rnd_65x39_AP_MX_Sand) {
-    MACRO_65_MAGAZINE_MX_Black
+    MACRO_65_MAGAZINE_MX_Black;
     displayName = "6.5mm 30Rnd MX Black (AP)";
 };
 
 // 6.5x39mm (MX, MG Sand)
 class CLASS(100Rnd_65x39_Ball_MX_LSW_Sand): 100Rnd_65x39_caseless_mag {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(65x39_Ball);
     displayName = "6.5mm 100Rnd MX LSW Sand [TE4] (Ball)";
     displayNameShort = "Ball TE4";
@@ -68,21 +68,21 @@ class CLASS(100Rnd_65x39_EPR_MX_LSW_Sand): CLASS(100Rnd_65x39_Ball_MX_LSW_Sand) 
 
 // 6.5x39mm (MX, MG Black)
 class CLASS(100Rnd_65x39_Ball_MX_LSW_Black): CLASS(100Rnd_65x39_Ball_MX_LSW_Sand) {
-    MACRO_65_MAGAZINE_MX_LSW_Black
+    MACRO_65_MAGAZINE_MX_LSW_Black;
     displayName = "6.5mm 100Rnd MX LSW Black [TE4] (Ball)";
 };
 class CLASS(100Rnd_65x39_Ball_Tracer_MX_LSW_Black): CLASS(100Rnd_65x39_Ball_Tracer_MX_LSW_Sand) {
-    MACRO_65_MAGAZINE_MX_LSW_Black
+    MACRO_65_MAGAZINE_MX_LSW_Black;
     displayName = "6.5mm 100Rnd MX LSW Black [T] (Ball)";
 };
 class CLASS(100Rnd_65x39_EPR_MX_LSW_Black): CLASS(100Rnd_65x39_EPR_MX_LSW_Sand) {
-    MACRO_65_MAGAZINE_MX_LSW_Black
+    MACRO_65_MAGAZINE_MX_LSW_Black;
     displayName = "6.5mm 100Rnd MX LSW Black [TE4] (EPR)";
 };
 
 // 6.5x39mm (GROT/MSBS)
 class CLASS(30Rnd_65x39_Ball_MSBS): 30Rnd_65x39_caseless_msbs_mag {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(65x39_Ball);
     displayName = "6.5mm 30Rnd MSBS (Ball)";
     displayNameShort = "Ball";
@@ -110,7 +110,7 @@ class CLASS(30Rnd_65x39_AP_MSBS): CLASS(30Rnd_65x39_EPR_MSBS) {
 
 // 6.5x39mm Katiba/Type-115
 class CLASS(30Rnd_65x39_Ball_Katiba): 30Rnd_65x39_caseless_green {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(65x39_Ball);
     displayName = "6.5mm 30Rnd Katiba (Ball)";
     displayNameShort = "Ball";
@@ -138,7 +138,7 @@ class CLASS(30Rnd_65x39_AP_Katiba): CLASS(30Rnd_65x39_EPR_Katiba) {
 
 // 6.5x39mm Belt
 class CLASS(200Rnd_65x39_Ball_Belt): 200Rnd_65x39_cased_Box {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(65x39_Ball);
     displayName = "6.5mm 200Rnd Belt [TE4] (Ball)";
     displayNameShort = "Ball TE4";
@@ -160,7 +160,7 @@ class CLASS(200Rnd_65x39_EPR_Belt): CLASS(200Rnd_65x39_Ball_Belt) {
 
 // 6.5x39mm DMR
 class CLASS(20Rnd_65x39_Ball): 20Rnd_650x39_Cased_Mag_F {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(65x39_Ball);
     displayName = "6.5mm 20Rnd (Ball)";
     displayNameShort = "Ball";

--- a/addons/ammunition/bi/magazines/762x39.hpp
+++ b/addons/ammunition/bi/magazines/762x39.hpp
@@ -1,6 +1,6 @@
 // 7.62x39mm (Plastic, Black)
 class CLASS(30Rnd_762x39_Ball_Plastic_Black): 30Rnd_762x39_AK12_Mag_F {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(762x39_Ball);
     displayName = "7.62mm 30Rnd AK Plastic Black (Ball)";
     displayNameShort = "Ball";
@@ -29,26 +29,26 @@ class CLASS(30Rnd_762x39_AP_Plastic_Black): CLASS(30Rnd_762x39_EPR_Plastic_Black
 
 // 7.62x39mm (Plastic, Tan)
 class CLASS(30Rnd_762x39_Ball_Plastic_Tan): CLASS(30Rnd_762x39_Ball_Plastic_Black) {
-    MACRO_762_AK12_MAGAZINE_TAN
+    MACRO_762_AK12_MAGAZINE_TAN;
     displayName = "7.62mm 30Rnd AK Plastic Tan (Ball)";
     mass = 11;
 };
 class CLASS(30Rnd_762x39_Ball_Tracer_Plastic_Tan): CLASS(30Rnd_762x39_Ball_Tracer_Plastic_Black) {
-    MACRO_762_AK12_MAGAZINE_TAN
+    MACRO_762_AK12_MAGAZINE_TAN;
     displayName = "7.62mm 30Rnd AK Plastic Tan [T] (Ball)";
 };
 class CLASS(30Rnd_762x39_EPR_Plastic_Tan): CLASS(30Rnd_762x39_EPR_Plastic_Black) {
-    MACRO_762_AK12_MAGAZINE_TAN
+    MACRO_762_AK12_MAGAZINE_TAN;
     displayName = "7.62mm 30Rnd AK Plastic Tan (EPR)";
 };
 class CLASS(30Rnd_762x39_AP_Plastic_Tan): CLASS(30Rnd_762x39_AP_Plastic_Black) {
-    MACRO_762_AK12_MAGAZINE_TAN
+    MACRO_762_AK12_MAGAZINE_TAN;
     displayName = "7.62mm 30Rnd AK Plastic Tan (AP)";
 };
 
 // 7.62x39mm (Metal)
 class CLASS(30Rnd_762x39_Ball_Metal): 30Rnd_762x39_Mag_F {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(762x39_Ball);
     displayName = "7.62mm 30Rnd AK Metal (Ball)";
     displayNameShort = "Ball";
@@ -77,7 +77,7 @@ class CLASS(30Rnd_762x39_AP_Metal): CLASS(30Rnd_762x39_EPR_Metal) {
 
 // 7.62x39mm (Drum)
 class CLASS(75Rnd_762x39_Ball_Drum): 75rnd_762x39_AK12_Mag_F {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(762x39_Ball);
     displayName = "7.62mm 75Rnd AK Drum [TE4] (Ball)";
     displayNameShort = "Ball TE4";

--- a/addons/ammunition/bi/magazines/762x51.hpp
+++ b/addons/ammunition/bi/magazines/762x51.hpp
@@ -1,6 +1,6 @@
 // 7.62x51mm
 class CLASS(20Rnd_762x51_Ball): 20Rnd_762x51_Mag {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(762x51_Ball);
     displayName = "7.62mm 20Rnd (Ball)";
     displayNameShort = "Ball";

--- a/addons/ammunition/bi/magazines/762x54r.hpp
+++ b/addons/ammunition/bi/magazines/762x54r.hpp
@@ -1,6 +1,6 @@
 // 7.62x54r Negev Boxes
 class CLASS(150Rnd_762x54r_Ball_Belt): 150Rnd_762x54_Box {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(762x54r_Ball);
     displayName = "7.62mm 150Rnd Belt [TE4] (Ball)";
     displayNameShort = "Ball TE4";
@@ -23,7 +23,7 @@ class CLASS(150Rnd_762x54r_EPR_Belt): CLASS(150Rnd_762x54r_Ball_Belt) {
 
 // 7.62x54r SVD/VS-121 Magazines
 class CLASS(10Rnd_762x54r_Ball): 10Rnd_762x54_Mag {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(762x54r_Ball);
     displayName = "7.62mm 10Rnd (Ball)";
     displayNameShort = "Ball";

--- a/addons/ammunition/bi/magazines/9x19.hpp
+++ b/addons/ammunition/bi/magazines/9x19.hpp
@@ -1,6 +1,6 @@
 class 16Rnd_9x21_Mag;
 class CLASS(17Rnd_9x19mm_Walther_Ball): 16Rnd_9x21_Mag {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(9x19_Ball);
     descriptionShort = "9x19mm Ball Reload Tracer";
     displayName = "9mm 17Rnd Walther (Ball)";
@@ -9,7 +9,7 @@ class CLASS(17Rnd_9x19mm_Walther_Ball): 16Rnd_9x21_Mag {
 
 // 9x19mm
 class CLASS(30Rnd_9x19_Ball): 30Rnd_9x21_Mag {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(9x19_Ball);
     displayName = "9mm 30Rnd (Ball)";
     displayNameShort = "Ball";

--- a/addons/ammunition/cup/CfgAmmo.hpp
+++ b/addons/ammunition/cup/CfgAmmo.hpp
@@ -7,7 +7,7 @@ class CfgAmmo {
         aiAmmoUsageFlags = "64 + 128";
         caliber = 1.5;
         hit = 12;
-        MACRO_TRACERS
+        MACRO_TRACERS;
         ACE_caliber = 5.7;
         ACE_bulletLength = 21.6;
         ACE_bulletMass = 2;
@@ -18,6 +18,7 @@ class CfgAmmo {
     // 4.6x30mm (Comparable to 5.7x28mm but slightly worse performing penetration.)
     class CLASS(46x30_Ball): CLASS(57x28_Ball) {
         caliber = 0.15;
+        cartridge = "FxCartridge_9mm";
         hit = 8;
     };
     class CLASS(46x30_EPR): CLASS(46x30_Ball) {
@@ -33,8 +34,9 @@ class CfgAmmo {
     class CLASS(9x39_Ball): CUP_B_9x39_SP5 {
         aiAmmoUsageFlags = "64 + 128";
         caliber = 0.15;
+        cartridge = "FxCartridge_9mm";
         hit = 10;
-        MACRO_TRACERS
+        MACRO_TRACERS;
     };
     class CLASS(9x39_EPR): CLASS(9x39_Ball) {
         caliber = 1.1;

--- a/addons/ammunition/cup/magazines/12g.hpp
+++ b/addons/ammunition/cup/magazines/12g.hpp
@@ -1,6 +1,6 @@
 // 8Rnd Saiga
 class CLASS(8Rnd_Saiga_000): CUP_5Rnd_B_Saiga12_Buck_00 {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(P_12G_000);
     count = 8;
     displayName = "8Rnd Saiga (Magnum)";

--- a/addons/ammunition/cup/magazines/45ACP.hpp
+++ b/addons/ammunition/cup/magazines/45ACP.hpp
@@ -1,7 +1,7 @@
 // .45ACP 1911
 class CUP_7Rnd_45ACP_1911;
 class CLASS(8Rnd_45ACP_1911_Ball): CUP_7Rnd_45ACP_1911 {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(45ACP_Ball);
     descriptionShort = ".45ACP Ball Reload Tracer";
     displayName = ".45ACP 8Rnd 1911 (Ball)";
@@ -11,7 +11,7 @@ class CLASS(8Rnd_45ACP_1911_Ball): CUP_7Rnd_45ACP_1911 {
 // .45ACP MK23 SOCOM
 class CUP_12Rnd_45ACP_mk23;
 class CLASS(12Rnd_45ACP_MK23_Ball): CUP_12Rnd_45ACP_mk23 {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(45ACP_Ball);
     descriptionShort = ".45ACP Ball Reload Tracer";
     displayName = ".45ACP 12Rnd MK23 (Ball)";

--- a/addons/ammunition/cup/magazines/46x30.hpp
+++ b/addons/ammunition/cup/magazines/46x30.hpp
@@ -1,6 +1,6 @@
 // 4.6x30mm
 class CLASS(40Rnd_46x30_Ball): CUP_40Rnd_46x30_MP7 {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(46x30_Ball);
     displayName = "4.6mm 40Rnd (Ball)";
     displayNameShort = "Ball";

--- a/addons/ammunition/cup/magazines/545x39.hpp
+++ b/addons/ammunition/cup/magazines/545x39.hpp
@@ -1,6 +1,6 @@
 // 5.45x39mm Quadstack
 class CLASS(60Rnd_545x39_Ball_Quadstack): CUP_60Rnd_545x39_AK74M_M {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(545x39_Ball);
     displayName = "5.45mm 60Rnd Quadstack [TE4] (Ball)";
     displayNameShort = "Ball TE4";
@@ -23,7 +23,7 @@ class CLASS(60Rnd_545x39_EPR_Quadstack): CLASS(60Rnd_545x39_Ball_Quadstack) {
 
 // 5.45x39mm Fort
 class CLASS(30Rnd_545x39_Ball_Fort): CUP_30Rnd_545x39_Fort224_M {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(545x39_Ball);
     displayName = "5.45mm 30Rnd Fort (Ball)";
     displayNameShort = "Ball";

--- a/addons/ammunition/cup/magazines/556x45.hpp
+++ b/addons/ammunition/cup/magazines/556x45.hpp
@@ -1,7 +1,7 @@
 // 5.56x45mm (EMAG, Black)
 class CLASS(30Rnd_556x45_Ball_EMAG): 30Rnd_556x45_Stanag {
-    MACRO_SCOPE
-    MACRO_556_MAGAZINE_EMAG_Black
+    MACRO_SCOPE;
+    MACRO_556_MAGAZINE_EMAG_Black;
     ammo = QCLASS(556x45_Ball);
     displayName = "5.56mm 30Rnd EMAG (Ball)";
     displayNameShort = "Ball";
@@ -30,61 +30,61 @@ class CLASS(30Rnd_556x45_AP_EMAG): CLASS(30Rnd_556x45_EPR_EMAG) {
 
 // 5.56x45mm (EMAG, Tan)
 class CLASS(30Rnd_556x45_Ball_EMAG_Tan): CLASS(30Rnd_556x45_Ball_EMAG) {
-    MACRO_556_MAGAZINE_EMAG_Tan
+    MACRO_556_MAGAZINE_EMAG_Tan;
     displayName = "5.56mm 30Rnd EMAG Tan (Ball)";
 };
 class CLASS(30Rnd_556x45_Ball_Tracer_EMAG_Tan): CLASS(30Rnd_556x45_Ball_Tracer_EMAG) {
-    MACRO_556_MAGAZINE_EMAG_Tan
+    MACRO_556_MAGAZINE_EMAG_Tan;
     displayName = "5.56mm 30Rnd EMAG Tan [T] (Ball)";
 };
 class CLASS(30Rnd_556x45_EPR_EMAG_Tan): CLASS(30Rnd_556x45_EPR_EMAG) {
-    MACRO_556_MAGAZINE_EMAG_Tan
+    MACRO_556_MAGAZINE_EMAG_Tan;
     displayName = "5.56mm 30Rnd EMAG Tan (EPR)";
 };
 class CLASS(30Rnd_556x45_AP_EMAG_Tan): CLASS(30Rnd_556x45_AP_EMAG) {
-    MACRO_556_MAGAZINE_EMAG_Tan
+    MACRO_556_MAGAZINE_EMAG_Tan;
     displayName = "5.56mm 30Rnd EMAG Tan (AP)";
 };
 
 // 5.56x45mm (PMAG, Black)
 class CLASS(30Rnd_556x45_Ball_PMAG): CLASS(30Rnd_556x45_Ball_EMAG) {
-    MACRO_556_MAGAZINE_PMAG_Black
+    MACRO_556_MAGAZINE_PMAG_Black;
     displayName = "5.56mm 30Rnd PMAG (Ball)";
 };
 class CLASS(30Rnd_556x45_Ball_Tracer_PMAG): CLASS(30Rnd_556x45_Ball_Tracer_EMAG) {
-    MACRO_556_MAGAZINE_PMAG_Black
+    MACRO_556_MAGAZINE_PMAG_Black;
     displayName = "5.56mm 30Rnd PMAG [T] (Ball)";
 };
 class CLASS(30Rnd_556x45_EPR_PMAG): CLASS(30Rnd_556x45_EPR_EMAG) {
-    MACRO_556_MAGAZINE_PMAG_Black
+    MACRO_556_MAGAZINE_PMAG_Black;
     displayName = "5.56mm 30Rnd PMAG (EPR)";
 };
 class CLASS(30Rnd_556x45_AP_PMAG): CLASS(30Rnd_556x45_AP_EMAG) {
-    MACRO_556_MAGAZINE_PMAG_Black
+    MACRO_556_MAGAZINE_PMAG_Black;
     displayName = "5.56mm 30Rnd PMAG (AP)";
 };
 
 // 5.56x45mm (PMAG, Tan)
 class CLASS(30Rnd_556x45_Ball_PMAG_Tan): CLASS(30Rnd_556x45_Ball_PMAG) {
-    MACRO_556_MAGAZINE_PMAG_Tan
+    MACRO_556_MAGAZINE_PMAG_Tan;
     displayName = "5.56mm 30Rnd PMAG Coyote (Ball)";
 };
 class CLASS(30Rnd_556x45_Ball_Tracer_PMAG_Tan): CLASS(30Rnd_556x45_Ball_Tracer_PMAG) {
-    MACRO_556_MAGAZINE_PMAG_Tan
+    MACRO_556_MAGAZINE_PMAG_Tan;
     displayName = "5.56mm 30Rnd PMAG Coyote [T] (Ball)";
 };
 class CLASS(30Rnd_556x45_EPR_PMAG_Tan): CLASS(30Rnd_556x45_EPR_PMAG) {
-    MACRO_556_MAGAZINE_PMAG_Tan
+    MACRO_556_MAGAZINE_PMAG_Tan;
     displayName = "5.56mm 30Rnd PMAG Coyote (EPR)";
 };
 class CLASS(30Rnd_556x45_AP_PMAG_Tan): CLASS(30Rnd_556x45_AP_PMAG) {
-    MACRO_556_MAGAZINE_PMAG_Tan
+    MACRO_556_MAGAZINE_PMAG_Tan;
     displayName = "5.56mm 30Rnd PMAG Coyote (AP)";
 };
 
 // 5.56x45mm AK
 class CLASS(30Rnd_556x45_Ball_AK): CUP_30Rnd_556x45_AK {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(556x45_Ball);
     displayName = "5.56mm 30Rnd AK (Ball)";
     displayNameShort = "Ball";
@@ -113,7 +113,7 @@ class CLASS(30Rnd_556x45_AP_AK): CLASS(30Rnd_556x45_EPR_AK) {
 
 // 5.56x45mm G36
 class CLASS(30Rnd_556x45_Ball_G36): CUP_30Rnd_TE1_Green_Tracer_556x45_G36 {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(556x45_Ball);
     displayName = "5.56mm 30Rnd G36 (Ball)";
     displayNameShort = "Ball";
@@ -143,7 +143,7 @@ class CLASS(30Rnd_556x45_AP_G36): CLASS(30Rnd_556x45_Ball_G36) {
 
 // 5.56x45mm FAMAS
 class CLASS(25Rnd_556x45_Ball_FAMAS): CUP_25Rnd_556x45_Famas {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(556x45_Ball);
     displayName = "5.56mm 25Rnd FAMAS (Ball)";
     displayNameShort = "Ball";
@@ -172,7 +172,7 @@ class CLASS(25Rnd_556x45_AP_FAMAS): CLASS(25Rnd_556x45_Ball_FAMAS) {
 
 // 5.56x45mm Surefire 60Rnd
 class CLASS(60Rnd_556x45_Ball_Surefire): CUP_60Rnd_556x45_SureFire {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(556x45_Ball);
     displayName = "5.56mm 60Rnd Surefire [TE4] (Ball)";
     displayNameShort = "Ball TE4";
@@ -195,7 +195,7 @@ class CLASS(60Rnd_556x45_EPR_Surefire): CLASS(60Rnd_556x45_Ball_Surefire) {
 
 /// 5.56x45mm Beta-C
 class CLASS(100Rnd_556x45_Ball_BetaC): CUP_100Rnd_556x45_BetaCMag {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(556x45_Ball);
     displayName = "5.56mm 100Rnd Beta-C [TE4] (Ball)";
     displayNameShort = "Ball TE4";
@@ -218,7 +218,7 @@ class CLASS(100Rnd_556x45_EPR_BetaC): CLASS(100Rnd_556x45_Ball_BetaC) {
 
 // 5.56x45mm M249 Pouch 100
 class CLASS(100Rnd_556x54_Ball_Pouch): CUP_100Rnd_TE4_Green_Tracer_556x45_M249 {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(556x45_Ball);
     displayName = "5.56mm 100Rnd M249 Pouch [TE4] (Ball)";
     displayNameShort = "Ball TE4";
@@ -241,7 +241,7 @@ class CLASS(100Rnd_556x54_EPR_Pouch): CLASS(100Rnd_556x54_Ball_Pouch) {
 
 // 5.56x45mm M249 Pouch 200
 class CLASS(200Rnd_556x45_Ball_Pouch): CUP_200Rnd_TE4_Green_Tracer_556x45_M249_Pouch {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(556x45_Ball);
     displayName = "5.56mm 200Rnd M249 Pouch [TE4] (Ball)";
     displayNameShort = "Ball TE4";
@@ -264,7 +264,7 @@ class CLASS(200Rnd_556x45_EPR_Pouch): CLASS(200Rnd_556x45_Ball_Pouch) {
 
 // 5.56x45mm M249 Box 200
 class CLASS(200Rnd_556x45_Ball_Box): CUP_200Rnd_TE4_Green_Tracer_556x45_M249 {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(556x45_Ball);
     displayName = "5.56mm 200Rnd M249 Box [TE4] (Ball)";
     displayNameShort = "Ball TE4";

--- a/addons/ammunition/cup/magazines/68x43.hpp
+++ b/addons/ammunition/cup/magazines/68x43.hpp
@@ -1,6 +1,6 @@
 // 6.8x43mm ACR
 class CLASS(30Rnd_68x43_Ball_ACR): CUP_30Rnd_680x43_Stanag {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(68x43_Ball);
     displayName = "6.8mm 30Rnd ACR (Ball)";
     displayNameShort = "Ball";

--- a/addons/ammunition/cup/magazines/762x39.hpp
+++ b/addons/ammunition/cup/magazines/762x39.hpp
@@ -1,6 +1,6 @@
 // 7.62x39mm CZ807
 class CLASS(30Rnd_762x39_Ball_CZ): CUP_30Rnd_762x39_CZ807 {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(762x39_Ball);
     displayName = "7.62mm 30Rnd CZ (Ball)";
     displayNameShort = "Ball";

--- a/addons/ammunition/cup/magazines/762x51.hpp
+++ b/addons/ammunition/cup/magazines/762x51.hpp
@@ -1,6 +1,6 @@
 // 7.62x51mm FAL
 class CLASS(20Rnd_762x51_Ball_FAL): CUP_20Rnd_762x51_FNFAL_M {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(762x51_Ball);
     displayName = "7.62mm 20Rnd FAL (Ball)";
     displayNameShort = "Ball";
@@ -29,7 +29,7 @@ class CLASS(20Rnd_762x51_AP_FAL): CLASS(20Rnd_762x51_EPR_FAL) {
 
 // 7.62x51mm SCAR-H
 class CLASS(20Rnd_762x51_Ball_SCAR): CUP_20Rnd_762x51_B_SCAR_bkl {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(762x51_Ball);
     displayName = "7.62mm 20Rnd SCAR (Ball)";
     displayNameShort = "Ball";

--- a/addons/ammunition/cup/magazines/9x19.hpp
+++ b/addons/ammunition/cup/magazines/9x19.hpp
@@ -1,7 +1,7 @@
 // 9x19 Browning
 class CUP_13Rnd_9x19_Browning_HP;
 class CLASS(13Rnd_9x19_Browning_Ball): CUP_13Rnd_9x19_Browning_HP {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(9x19_Ball);
     descriptionShort = "9x19mm Ball Reload Tracer";
     displayName = "9mm 13Rnd Browning (Ball)";
@@ -11,7 +11,7 @@ class CLASS(13Rnd_9x19_Browning_Ball): CUP_13Rnd_9x19_Browning_HP {
 // 9x19 CZ75
 class CUP_18Rnd_9x19_Phantom;
 class CLASS(18Rnd_9x19_CZ75_Ball): CUP_18Rnd_9x19_Phantom {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(9x19_Ball);
     descriptionShort = "9x19mm Ball Reload Tracer";
     displayName = "9mm 18Rnd CZ75 (Ball)";
@@ -21,7 +21,7 @@ class CLASS(18Rnd_9x19_CZ75_Ball): CUP_18Rnd_9x19_Phantom {
 // 9x19 Glock
 class CUP_17Rnd_9x19_glock17;
 class CLASS(17Rnd_9x19_Glock_Ball): CUP_17Rnd_9x19_glock17 {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(9x19_Ball);
     descriptionShort = "9x19mm Ball Reload Tracer";
     displayName = "9mm 17Rnd Glock (Ball)";
@@ -31,7 +31,7 @@ class CLASS(17Rnd_9x19_Glock_Ball): CUP_17Rnd_9x19_glock17 {
 // 9x19 M17
 class CUP_17Rnd_9x19_M17_Black;
 class CLASS(17Rnd_9x19_M17_Ball): CUP_17Rnd_9x19_M17_Black {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(9x19_Ball);
     descriptionShort = "9x19mm Ball Reload Tracer";
     displayName = "9mm 17Rnd M17 (Ball)";
@@ -41,7 +41,7 @@ class CLASS(17Rnd_9x19_M17_Ball): CUP_17Rnd_9x19_M17_Black {
 // 9x19 M9
 class CUP_15Rnd_9x19_M9;
 class CLASS(15Rnd_9x19_M9_Ball): CUP_15Rnd_9x19_M9 {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(9x19_Ball);
     descriptionShort = "9x19mm Ball Reload Tracer";
     displayName = "9mm 15Rnd M9 (Ball)";
@@ -50,7 +50,7 @@ class CLASS(15Rnd_9x19_M9_Ball): CUP_15Rnd_9x19_M9 {
 
 // 9x19mm MP5
 class CLASS(30Rnd_9x19_Ball_MP5): CUP_30Rnd_9x19_MP5 {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(9x19_Ball);
     displayName = "9mm 30Rnd MP5 (Ball)";
     displayNameShort = "Ball";
@@ -79,7 +79,7 @@ class CLASS(30Rnd_9x19_AP_MP5): CLASS(30Rnd_9x19_EPR_MP5) {
 
 // 9x19mm Vityaz
 class CLASS(30Rnd_9x19_Ball_Vityaz): CUP_30Rnd_9x19_Vityaz {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(9x19_Ball);
     displayName = "9mm 30Rnd Vityaz (Ball)";
     displayNameShort = "Ball";
@@ -108,7 +108,7 @@ class CLASS(30Rnd_9x19_AP_Vityaz): CLASS(30Rnd_9x19_EPR_Vityaz) {
 
 // 9x19 Bizon
 class CLASS(64Rnd_9x19_Ball_Bizon): CUP_64Rnd_9x19_Bizon_M {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(9x19_Ball);
     displayName = "9mm 64Rnd Bizon (Ball)";
     displayNameShort = "Ball";

--- a/addons/ammunition/cup/magazines/9x39.hpp
+++ b/addons/ammunition/cup/magazines/9x39.hpp
@@ -1,6 +1,6 @@
 // 9x39mm
 class CLASS(30Rnd_9x39_Ball): CUP_30Rnd_9x39_SP5_VIKHR_M {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(9x39_Ball);
     displayName = "9x39mm 30Rnd (Ball)";
     displayNameShort = "Ball";

--- a/addons/ammunition/niarms/CfgAmmo.hpp
+++ b/addons/ammunition/niarms/CfgAmmo.hpp
@@ -5,8 +5,9 @@ class CfgAmmo {
     class CLASS(300AAC_Ball): HLC_300Blackout_Ball {
         aiAmmoUsageFlags = "64 + 128";
         caliber = 0.19;
+        cartridge = "FxCartridge_762";
         hit = 12;
-        MACRO_TRACERS
+        MACRO_TRACERS;
     };
     class CLASS(300AAC_EPR): CLASS(300AAC_Ball) {
         caliber = 1.2;

--- a/addons/ammunition/niarms/magazines/10mm.hpp
+++ b/addons/ammunition/niarms/magazines/10mm.hpp
@@ -1,5 +1,5 @@
 class CLASS(10mm_Ball_Special): hlc_15Rnd_9x19_B_P226 {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(10mm_Ball);
     descriptionShort = "10mm Auto Ball Reload Tracer";
     displayName = "10mm 8Rnd M11 10th Legion (Ball)";

--- a/addons/ammunition/niarms/magazines/300Blackout.hpp
+++ b/addons/ammunition/niarms/magazines/300Blackout.hpp
@@ -1,5 +1,5 @@
 class CLASS(30Rnd_300AAC_Ball): hlc_29rnd_300BLK_STANAG {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(300AAC_Ball);
     displayName = ".300AAC 30Rnd (Ball)";
     displayNameShort = "Ball";

--- a/addons/ammunition/niarms/magazines/357.hpp
+++ b/addons/ammunition/niarms/magazines/357.hpp
@@ -1,7 +1,7 @@
 // .357 SIG
 class hlc_12Rnd_357SIG_B_P226;
 class CLASS(12Rnd_357_P226_Magnum): hlc_12Rnd_357SIG_B_P226 {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(357_Magnum);
     descriptionShort = ".357 Magnum Reload Tracer";
     displayName = ".357 12Rnd P226 (Magnum)";
@@ -10,7 +10,7 @@ class CLASS(12Rnd_357_P226_Magnum): hlc_12Rnd_357SIG_B_P226 {
 
 class hlc_8Rnd_357SIG_B_P239;
 class CLASS(8Rnd_357_P239_Magnum): hlc_8Rnd_357SIG_B_P239 {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(357_Magnum);
     descriptionShort = ".357 Magnum Reload Tracer";
     displayName = ".357 8Rnd P239 (Magnum)";

--- a/addons/ammunition/niarms/magazines/556x45.hpp
+++ b/addons/ammunition/niarms/magazines/556x45.hpp
@@ -1,6 +1,6 @@
 // 5.56x45mm SG55X Series
 class CLASS(30Rnd_556x45_Ball_SG): hlc_30Rnd_556x45_EPR_sg550 {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(556x45_Ball);
     displayName = "5.56mm 30Rnd SiG (Ball)";
     displayNameShort = "Ball";
@@ -29,7 +29,7 @@ class CLASS(30Rnd_556x45_AP_SG): CLASS(30Rnd_556x45_EPR_SG) {
 
 // 5.56x45mm AUG
 class CLASS(30Rnd_556x45_Ball_AUG): hlc_30Rnd_556x45_B_AUG {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(556x45_Ball);
     displayName = "5.56mm 30Rnd AUG (Ball)";
     displayNameShort = "Ball";
@@ -58,7 +58,7 @@ class CLASS(30Rnd_556x45_AP_AUG): CLASS(30Rnd_556x45_EPR_AUG) {
 
 // 5.56x45mm AUG 42Rnd
 class CLASS(42Rnd_556x45_Ball_AUG): hlc_40Rnd_556x45_B_AUG {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(556x45_Ball);
     displayName = "5.56mm 42Rnd AUG (Ball)";
     displayNameShort = "Ball";

--- a/addons/ammunition/niarms/magazines/762x51.hpp
+++ b/addons/ammunition/niarms/magazines/762x51.hpp
@@ -1,6 +1,6 @@
 // 7.62x51mm Belt
 class CLASS(100Rnd_762x51_Ball_Belt): hlc_100Rnd_762x51_B_M60E4 {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(762x51_Ball);
     displayName = "7.62mm 100Rnd [TE4] (Ball)";
     displayNameShort = "Ball TE4";

--- a/addons/ammunition/niarms/magazines/9x19.hpp
+++ b/addons/ammunition/niarms/magazines/9x19.hpp
@@ -1,7 +1,7 @@
 // 9x19 SIG
 class hlc_15Rnd_9x19_B_P226;
 class CLASS(15Rnd_9x19_P226_Ball): hlc_15Rnd_9x19_B_P226 {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(9x19_Ball);
     descriptionShort = "9x19mm Ball Reload Tracer";
     displayName = "9mm 15Rnd P226 (Ball)";
@@ -11,7 +11,7 @@ class CLASS(15Rnd_9x19_P226_Ball): hlc_15Rnd_9x19_B_P226 {
 // 9x19 SIG P239
 class hlc_10Rnd_9x19_B_P239;
 class CLASS(10Rnd_9x19_P239_Ball): hlc_10Rnd_9x19_B_P239 {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(9x19_Ball);
     descriptionShort = "9x19mm Ball Reload Tracer";
     displayName = "9mm 10Rnd P239 (Ball)";

--- a/addons/ammunition/script_macros.hpp
+++ b/addons/ammunition/script_macros.hpp
@@ -1,13 +1,13 @@
 #define MACRO_SCOPE \
     scope = 2; \
     scopeArsenal = 2; \
-    author = ECSTRING(main,Author);
+    author = ECSTRING(main,Author)
 
 #define MACRO_TRACERS \
-    model = "\A3\Weapons_f\Data\bullettracer\tracer_Yellow";
-    tracerEndTime = 1;
-    tracerScale = 0.5;
-    tracerstartTime = 0.05;
+    model = "\A3\Weapons_f\Data\bullettracer\tracer_Yellow"; \
+    tracerEndTime = 1; \
+    tracerScale = 0.5; \
+    tracerstartTime = 0.05
 
 #define MACRO_AK12_MAGAZINE_TAN \
     hiddenSelections[] = {"Camo1"}; \
@@ -15,7 +15,7 @@
     model = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines\CUP_mag_30Rnd_AK12.p3d"; \
     modelSpecial = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines_proxy\CUP_mag_30Rnd_AK12.p3d"; \
     modelSpecialIsProxy = 1; \
-    picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_ak74_ca.paa";
+    picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_ak74_ca.paa"
 
 #define MACRO_AK12_MAGAZINE_BLACK \
     hiddenSelections[] = {"Camo1"}; \
@@ -23,7 +23,7 @@
     model = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines\CUP_mag_30Rnd_AK12.p3d"; \
     modelSpecial = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines_proxy\CUP_mag_30Rnd_AK12.p3d"; \
     modelSpecialIsProxy = 1; \
-    picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_ak74_ca.paa";
+    picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_ak74_ca.paa"
 
 #define MACRO_556_MAGAZINE_PMAG_Black \
     hiddenSelections[] = {"Camo1"}; \
@@ -31,36 +31,36 @@
     model = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines\CUP_mag_30rnd_pmag.p3d"; \
     modelSpecial = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines_proxy\CUP_mag_30rnd_pmag.p3d"; \
     modelSpecialIsProxy = 1; \
-    picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_30rnd_pmag_black_ca.paa";
+    picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_30rnd_pmag_black_ca.paa"
 
 #define MACRO_556_MAGAZINE_PMAG_Tan \
     hiddenSelections[] = {"Camo1"}; \
     hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\cup_pmag_coyote_co.paa"}; \
-    picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_30rnd_pmag_coyote_ca.paa";
+    picture = "\CUP\Weapons\CUP_Weapons_Ammunition\data\ui\m_30rnd_pmag_coyote_ca.paa"
 
 #define MACRO_556_MAGAZINE_EMAG_Black \
     hiddenSelections[] = {"Camo1"}; \
     hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\emag_co.paa"}; \
     model = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines\CUP_mag_30Rnd_EMAG.p3d"; \
     modelSpecial = "\CUP\Weapons\CUP_Weapons_Ammunition\magazines_proxy\CUP_mag_30Rnd_EMAG.p3d"; \
-    modelSpecialIsProxy = 1;
+    modelSpecialIsProxy = 1
 
 #define MACRO_556_MAGAZINE_EMAG_Tan \
     hiddenSelections[] = {"Camo1"}; \
-    hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\emag_coyote_co.paa"};
+    hiddenSelectionsTextures[] = {"\CUP\Weapons\CUP_Weapons_Ammunition\magazines\data\emag_coyote_co.paa"}
 
 #define MACRO_65_MAGAZINE_MX_Black \
     hiddenSelections[] = {"camo"}; \
     hiddenSelectionsTextures[] = {"\A3\Weapons_F_EPB\Rifles\MX_Black\Data\XMX_Base_Black_co.paa"}; \
-    picture = "\a3\Weapons_F\MagazineProxies\data\UI\icon_30Rnd_65x39_caseless_black_mag_CA.paa";
+    picture = "\a3\Weapons_F\MagazineProxies\data\UI\icon_30Rnd_65x39_caseless_black_mag_CA.paa"
 
 #define MACRO_65_MAGAZINE_MX_LSW_Black \
     hiddenSelections[] = {"camo"}; \
     hiddenSelectionsTextures[] = {"\A3\Weapons_F_EPB\Rifles\MX_Black\Data\XMX_lmg_Black_co.paa"}; \
-    picture = "\a3\Weapons_F\MagazineProxies\data\UI\icon_100Rnd_65x39_caseless_black_mag_CA.paa";
+    picture = "\a3\Weapons_F\MagazineProxies\data\UI\icon_100Rnd_65x39_caseless_black_mag_CA.paa"
 
 #define MACRO_762_AK12_MAGAZINE_TAN \
     hiddenSelections[] = {"Camo"}; \
     hiddenSelectionsMaterials[] = {"a3\Weapons_F_Enoch\Rifles\AK12\Data\AK12_F_2_camo.rvmat"}; \
     hiddenSelectionsTextures[] = {"a3\Weapons_F_Enoch\Rifles\AK12\Data\ak12_ak12_2_camo_co.paa"}; \
-    picture = "\a3\Weapons_F_Enoch\MagazineProxies\data\UI\icon_30rnd_762x39_AK12_Arid_Mag_F_CA.paa";
+    picture = "\a3\Weapons_F_Enoch\MagazineProxies\data\UI\icon_30rnd_762x39_AK12_Arid_Mag_F_CA.paa"

--- a/addons/ammunition/ws/magazines/556x45.hpp
+++ b/addons/ammunition/ws/magazines/556x45.hpp
@@ -1,6 +1,6 @@
 // Western Sahara Assets
 class CLASS(35Rnd_556x45_Ball_R4): 35Rnd_556x45_Velko_reload_tracer_yellow_lxWS {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(556x45_Ball);
     displayName = "5.56mm 35Rnd R4 (Ball)";
     displayNameShort = "Ball";

--- a/addons/ammunition/ws/magazines/762x51.hpp
+++ b/addons/ammunition/ws/magazines/762x51.hpp
@@ -1,6 +1,6 @@
 // WS FAL (Original FAL magazines are not properly positioned)
 class CLASS(20Rnd_762x51_Ball_SLR): 20Rnd_762x51_slr_lxWS {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(762x51_Ball);
     displayName = "7.62mm 20Rnd SLR (Ball)";
     displayNameShort = "Ball";
@@ -29,7 +29,7 @@ class CLASS(20Rnd_762x51_AP_SLR): CLASS(20Rnd_762x51_Ball_SLR) {
 
 // Western Sahara Belt
 class CLASS(100Rnd_762x51_Ball_Belt_SA77): 100Rnd_762x51_S77_Yellow_lxWS {
-    MACRO_SCOPE
+    MACRO_SCOPE;
     ammo = QCLASS(762x51_Ball);
     displayName = "7.62mm 100Rnd SA-77 [TE4] (Ball)";
     displayNameShort = "Ball TE4";


### PR DESCRIPTION
- Most were missing the property and just using default 556 one.
- Also fixed macros from the component.
- Things look better now when firing a shotgun and the casings around you aren't just 5.56 ones.