### PR TITLE
Supplies - Fix Fuel canister not showing in Zeus

### DIFF
--- a/addons/supplies/config.cpp
+++ b/addons/supplies/config.cpp
@@ -16,7 +16,8 @@ class CfgPatches {
             QCLASS(Supply_Empty_3_1),
             QCLASS(Supply_Empty_3_2),
             QCLASS(Supply_Empty_4_1),
-            QCLASS(Supply_Empty_4_2)
+            QCLASS(Supply_Empty_4_2),
+            QCLASS(CanisterFuel_Theseus)
         };
         weapons[] = {};
         magazines[] = {};


### PR DESCRIPTION
- title
