### PR TITLE
Add NVG Component

### DIFF
--- a/addons/nvg/$PBOPREFIX$
+++ b/addons/nvg/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\tacgt\addons\nvg

--- a/addons/nvg/CfgWeapons.hpp
+++ b/addons/nvg/CfgWeapons.hpp
@@ -1,0 +1,32 @@
+#define MACRO_NVG_WP_PRESET \
+    modelOptics = ""; \
+    ace_nightvision_border = "z\ace\addons\nightvision\data\nvg_mask_quad_4096.paa"; \
+    ace_nightvision_bluRadius = 0.13; \
+    ace_nightvision_generation = 4; \
+    ace_nightvision_colorPreset[] = {0.0, {0.0, 0.0, 0.0, 0.0}, {1.1, 0.8, 1.9, 0.9}, {1, 1, 6, 0.0}}
+
+class CfgWeapons {
+    class CUP_NVG_GPNVG_black;
+    class CLASS(GPNVG_Black_WP): CUP_NVG_GPNVG_black {
+        displayName = "GPNVG (Black, WP)";
+        MACRO_NVG_WP_PRESET;
+    };
+
+    class CUP_NVG_GPNVG_green;
+    class CLASS(GPNVG_Green_WP): CUP_NVG_GPNVG_green {
+        displayName = "GPNVG (Green, WP)";
+        MACRO_NVG_WP_PRESET;
+    };
+
+    class CUP_NVG_GPNVG_tan;
+    class CLASS(GPNVG_Tan_WP): CUP_NVG_GPNVG_tan {
+        displayName = "GPNVG (Tan, WP)";
+        MACRO_NVG_WP_PRESET;
+    };
+
+    class CUP_NVG_GPNVG_winter;
+    class CLASS(GPNVG_Winter_WP): CUP_NVG_GPNVG_winter {
+        displayName = "GPNVG (Winter, WP)";
+        MACRO_NVG_WP_PRESET;
+    };
+};

--- a/addons/nvg/config.cpp
+++ b/addons/nvg/config.cpp
@@ -1,0 +1,23 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {
+            QCLASS(GPNVG_Black_WP),
+            QCLASS(GPNVG_Green_WP),
+            QCLASS(GPNVG_Tan_WP),
+            QCLASS(GPNVG_Winter_WP)
+        };
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"tacgt_main", "CUP_Weapons_NVG"};
+        skipWhenMissingDependencies = 1;
+        author = ECSTRING(main,Author);
+        authors[] = {"Mike"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgWeapons.hpp"

--- a/addons/nvg/script_component.hpp
+++ b/addons/nvg/script_component.hpp
@@ -1,0 +1,4 @@
+#define COMPONENT nvg
+#define COMPONENT_BEAUTIFIED NVG
+#include "\x\tacgt\addons\main\script_mod.hpp"
+#include "\x\tacgt\addons\main\script_macros.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- Currently just adds GPNVGs in White Phosphor. (Requires ACE 3.16.1 because of ace prefix on `colorPreset`.)