### PR TITLE
Training - Smoke Grenades

### DIFF
--- a/addons/training/CfgAmmo.hpp
+++ b/addons/training/CfgAmmo.hpp
@@ -58,4 +58,39 @@ class CfgAmmo {
         ace_explosives_magazine = QCLASS(SatchelCharge_Remote_Training_Mag);
         defaultMagazine = QCLASS(SatchelCharge_Remote_Training_Mag);
     };
+
+    class SmokeShell;
+    class CLASS(SmokeShell_Training_Ammo): SmokeShell {
+        timeToLive = 2;
+    };
+
+    class SmokeShellRed;
+    class CLASS(SmokeShellRed_Training_Ammo): SmokeShellRed {
+        timeToLive = 2;
+    };
+
+    class SmokeShellGreen;
+    class CLASS(SmokeShellGreen_Training_Ammo): SmokeShellGreen {
+        timeToLive = 2;
+    };
+
+    class SmokeShellYellow;
+    class CLASS(SmokeShellYellow_Training_Ammo): SmokeShellYellow {
+        timeToLive = 2;
+    };
+
+    class SmokeShellPurple;
+    class CLASS(SmokeShellPurple_Training_Ammo): SmokeShellPurple {
+        timeToLive = 2;
+    };
+
+    class SmokeShellBlue;
+    class CLASS(SmokeShellBlue_Training_Ammo): SmokeShellBlue {
+        timeToLive = 2;
+    };
+
+    class SmokeShellOrange;
+    class CLASS(SmokeShellOrange_Training_Ammo): SmokeShellOrange {
+        timeToLive = 2;
+    };
 };

--- a/addons/training/CfgMagazines.hpp
+++ b/addons/training/CfgMagazines.hpp
@@ -40,4 +40,47 @@ class CfgMagazines {
         displayName = "M183 Demolition Charge Assembly (Training)";
         ammo = QCLASS(SatchelCharge_Remote_Training_Ammo);
     };
+
+    class SmokeShell;
+    class CLASS(SmokeShell_Training): SmokeShell {
+        displayName = "M83 Smoke Shell (White, Training)";
+        ammo = QCLASS(SmokeShell_Training_Ammo);
+    };
+
+    class SmokeShellGreen;
+    class CLASS(SmokeShellGreen_Training): SmokeShellGreen {
+        displayName = "M18 Smoke Shell (Green, Training)";
+        ammo = QCLASS(SmokeShellGreen_Training_Ammo);
+    };
+
+
+    class SmokeShellRed;
+    class CLASS(SmokeShellRed_Training): SmokeShellRed {
+        displayName = "M18 Smoke Shell (Red, Training)";
+        ammo = QCLASS(SmokeShellRed_Training_Ammo);
+    };
+
+    class SmokeShellYellow;
+    class CLASS(SmokeShellYellow_Training): SmokeShellYellow {
+        displayName = "M18 Smoke Shell (Yellow, Training)";
+        ammo = QCLASS(SmokeShellYellow_Training_Ammo);
+    };
+
+    class SmokeShellPurple;
+    class CLASS(SmokeShellPurple_Training): SmokeShellPurple {
+        displayName = "M18 Smoke Shell (Purple, Training)";
+        ammo = QCLASS(SmokeShellPurple_Training_Ammo);
+    };
+
+    class SmokeShellBlue;
+    class CLASS(SmokeShellBlue_Training): SmokeShellBlue {
+        displayName = "M18 Smoke Shell (Blue, Training)";
+        ammo = QCLASS(SmokeShellBlue_Training_Ammo);
+    };
+
+    class SmokeShellOrange;
+    class CLASS(SmokeShellOrange_Training): SmokeShellOrange {
+        displayName = "M18 Smoke Shell (Orange, Training)";
+        ammo = QCLASS(SmokeShellOrange_Training_Ammo);
+    };
 };

--- a/addons/training/CfgMagazines.hpp
+++ b/addons/training/CfgMagazines.hpp
@@ -53,7 +53,6 @@ class CfgMagazines {
         ammo = QCLASS(SmokeShellGreen_Training_Ammo);
     };
 
-
     class SmokeShellRed;
     class CLASS(SmokeShellRed_Training): SmokeShellRed {
         displayName = "M18 Smoke Shell (Red, Training)";

--- a/addons/training/CfgWeapons.hpp
+++ b/addons/training/CfgWeapons.hpp
@@ -11,7 +11,22 @@ class CfgWeapons {
                 QCLASS(ATMine_Range_Training_Mag),
                 QCLASS(Claymore_Remote_Training_Mag),
                 QCLASS(DemoCharge_Remote_Training_Mag),
-                QCLASS(SatchelCharge_Remote_Training_Mag)
+                QCLASS(SatchelCharge_Remote_Training_Mag),
+            };
+        };
+    };
+    class Throw: Default {
+        muzzles[] += {QCLASS(training_muzzle)};
+        class ThrowMuzzle: Default {};
+        class CLASS(training_muzzle): ThrowMuzzle {
+            magazines[] = {
+                QCLASS(SmokeShell_Training),
+                QCLASS(SmokeShellBlue_Training),
+                QCLASS(SmokeShellGreen_Training),
+                QCLASS(SmokeShellOrange_Training),
+                QCLASS(SmokeShellPurple_Training),
+                QCLASS(SmokeShellRed_Training),
+                QCLASS(SmokeShellYellow_Training)
             };
         };
     };

--- a/addons/training/CfgWeapons.hpp
+++ b/addons/training/CfgWeapons.hpp
@@ -11,7 +11,7 @@ class CfgWeapons {
                 QCLASS(ATMine_Range_Training_Mag),
                 QCLASS(Claymore_Remote_Training_Mag),
                 QCLASS(DemoCharge_Remote_Training_Mag),
-                QCLASS(SatchelCharge_Remote_Training_Mag),
+                QCLASS(SatchelCharge_Remote_Training_Mag)
             };
         };
     };


### PR DESCRIPTION
**When merged this pull request will:**
- Adds training smokes
- Lifetime of 2 seconds instead of 60

Great for training with placement and signalling without having to deal with the smoke lingering