### PR TITLE
Ammunition - Switch from NiArms AUG mags to CUP

### DIFF
--- a/addons/ammunition/cup/CfgMagazineWells.hpp
+++ b/addons/ammunition/cup/CfgMagazineWells.hpp
@@ -131,6 +131,14 @@ class CfgMagazineWells {
             QCLASS(100Rnd_556x45_EPR_BetaC)
         };
     };
+    class CBA_556x45_STEYR {
+        ADDON[] = {
+            QCLASS(30Rnd_556x45_Ball_AUG),
+            QCLASS(30Rnd_556x45_Ball_Tracer_AUG),
+            QCLASS(30Rnd_556x45_EPR_AUG),
+            QCLASS(30Rnd_556x45_AP_AUG)
+        };
+    };
     class CBA_556x45_AK {
         ADDON[] = {
             QCLASS(30Rnd_556x45_Ball_AK),

--- a/addons/ammunition/cup/CfgMagazines.hpp
+++ b/addons/ammunition/cup/CfgMagazines.hpp
@@ -30,6 +30,7 @@ class CfgMagazines {
     class CUP_60Rnd_556x45_SureFire;
     class CUP_64Rnd_9x19_Bizon_M;
     class CUP_7Rnd_45ACP_1911;
+    class CUP_30Rnd_556x45_AUG;
 
     #include "magazines\12g.hpp"
     #include "magazines\45ACP.hpp"

--- a/addons/ammunition/cup/CfgMagazines.hpp
+++ b/addons/ammunition/cup/CfgMagazines.hpp
@@ -17,6 +17,7 @@ class CfgMagazines {
     class CUP_25Rnd_556x45_Famas;
     class CUP_30Rnd_545x39_Fort224_M;
     class CUP_30Rnd_556x45_AK;
+    class CUP_30Rnd_556x45_AUG;
     class CUP_30Rnd_680x43_Stanag;
     class CUP_30Rnd_762x39_CZ807;
     class CUP_30Rnd_9x19_MP5;
@@ -30,7 +31,6 @@ class CfgMagazines {
     class CUP_60Rnd_556x45_SureFire;
     class CUP_64Rnd_9x19_Bizon_M;
     class CUP_7Rnd_45ACP_1911;
-    class CUP_30Rnd_556x45_AUG;
 
     #include "magazines\12g.hpp"
     #include "magazines\45ACP.hpp"

--- a/addons/ammunition/cup/magazines/556x45.hpp
+++ b/addons/ammunition/cup/magazines/556x45.hpp
@@ -170,6 +170,35 @@ class CLASS(25Rnd_556x45_AP_FAMAS): CLASS(25Rnd_556x45_Ball_FAMAS) {
     descriptionShort = "5.56x45mm AP Reload Tracer";
 };
 
+// 5.56x45mm AUG
+class CLASS(30Rnd_556x45_Ball_AUG): CUP_30Rnd_556x45_AUG {
+    MACRO_SCOPE;
+    ammo = QCLASS(556x45_Ball);
+    displayName = "5.56mm 30Rnd AUG (Ball)";
+    displayNameShort = "Ball";
+    descriptionShort = "5.56x45mm Ball Reload Tracer";
+    lastRoundsTracer = 4;
+    mass = 10;
+};
+class CLASS(30Rnd_556x45_Ball_Tracer_AUG): CLASS(30Rnd_556x45_Ball_AUG) {
+    displayName = "5.56mm 30Rnd AUG [T] (Ball)";
+    displayNameShort = "Ball Tracer";
+    descriptionShort = "5.56x45mm Ball Tracer";
+    tracersEvery = 1;
+};
+class CLASS(30Rnd_556x45_EPR_AUG): CLASS(30Rnd_556x45_Ball_AUG) {
+    ammo = QCLASS(556x45_EPR);
+    displayName = "5.56mm 30Rnd AUG (EPR)";
+    displayNameShort = "EPR";
+    descriptionShort = "5.56x45mm EPR Reload Tracer";
+};
+class CLASS(30Rnd_556x45_AP_AUG): CLASS(30Rnd_556x45_EPR_AUG) {
+    ammo = QCLASS(556x45_AP);
+    displayName = "5.56mm 30Rnd AUG (AP)";
+    displayNameShort = "AP";
+    descriptionShort = "5.56x45mm AP Reload Tracer";
+};
+
 // 5.56x45mm Surefire 60Rnd
 class CLASS(60Rnd_556x45_Ball_Surefire): CUP_60Rnd_556x45_SureFire {
     MACRO_SCOPE;

--- a/addons/ammunition/niarms/CfgMagazineWells.hpp
+++ b/addons/ammunition/niarms/CfgMagazineWells.hpp
@@ -58,10 +58,6 @@ class CfgMagazineWells {
 
     class CBA_556x45_STEYR {
         ADDON[] = {
-            QCLASS(30Rnd_556x45_Ball_AUG),
-            QCLASS(30Rnd_556x45_Ball_Tracer_AUG),
-            QCLASS(30Rnd_556x45_EPR_AUG),
-            QCLASS(30Rnd_556x45_AP_AUG),
             QCLASS(42Rnd_556x45_Ball_AUG),
             QCLASS(42Rnd_556x45_Ball_Tracer_AUG),
             QCLASS(42Rnd_556x45_EPR_AUG),

--- a/addons/ammunition/niarms/CfgMagazines.hpp
+++ b/addons/ammunition/niarms/CfgMagazines.hpp
@@ -1,6 +1,5 @@
 class CfgMagazines {
     class hlc_30Rnd_556x45_EPR_sg550;
-    class hlc_30Rnd_556x45_B_AUG;
     class hlc_40Rnd_556x45_B_AUG;
     class hlc_100Rnd_762x51_B_M60E4;
     class hlc_29rnd_300BLK_STANAG;

--- a/addons/ammunition/niarms/magazines/556x45.hpp
+++ b/addons/ammunition/niarms/magazines/556x45.hpp
@@ -27,35 +27,6 @@ class CLASS(30Rnd_556x45_AP_SG): CLASS(30Rnd_556x45_EPR_SG) {
     descriptionShort = "5.56x45mm AP Reload Tracer";
 };
 
-// 5.56x45mm AUG
-class CLASS(30Rnd_556x45_Ball_AUG): hlc_30Rnd_556x45_B_AUG {
-    MACRO_SCOPE;
-    ammo = QCLASS(556x45_Ball);
-    displayName = "5.56mm 30Rnd AUG (Ball)";
-    displayNameShort = "Ball";
-    descriptionShort = "5.56x45mm Ball Reload Tracer";
-    lastRoundsTracer = 4;
-    mass = 10;
-};
-class CLASS(30Rnd_556x45_Ball_Tracer_AUG): CLASS(30Rnd_556x45_Ball_AUG) {
-    displayName = "5.56mm 30Rnd AUG [T] (Ball)";
-    displayNameShort = "Ball Tracer";
-    descriptionShort = "5.56x45mm Ball Tracer";
-    tracersEvery = 1;
-};
-class CLASS(30Rnd_556x45_EPR_AUG): CLASS(30Rnd_556x45_Ball_AUG) {
-    ammo = QCLASS(556x45_EPR);
-    displayName = "5.56mm 30Rnd AUG (EPR)";
-    displayNameShort = "EPR";
-    descriptionShort = "5.56x45mm EPR Reload Tracer";
-};
-class CLASS(30Rnd_556x45_AP_AUG): CLASS(30Rnd_556x45_EPR_AUG) {
-    ammo = QCLASS(556x45_AP);
-    displayName = "5.56mm 30Rnd AUG (AP)";
-    displayNameShort = "AP";
-    descriptionShort = "5.56x45mm AP Reload Tracer";
-};
-
 // 5.56x45mm AUG 42Rnd
 class CLASS(42Rnd_556x45_Ball_AUG): hlc_40Rnd_556x45_B_AUG {
     MACRO_SCOPE;


### PR DESCRIPTION
**When merged this pull request will:**
- Switches the 30Rnd mags from NiArms variants to CUPs, Don't like the stupid clear mags.
- Can't do anything about the 42Rnd ones but oh well.
- Classnames are the same, transition should be seamless.