### PR TITLE
Effects - Add Sparks & Increase impact effect size

### DIFF
--- a/addons/effects/CfgCloudlets.hpp
+++ b/addons/effects/CfgCloudlets.hpp
@@ -164,7 +164,6 @@ class CfgCloudlets {
         interval = 0.5;
         moveVelocity[] = {1, 1, 1};
         moveVelocityVar[] = {0.1, -1, 0.1};
-        postEffects = QCLASS(sparksSparkleEffect);
         size[] = {0.15, 0.05, 0};
     };
     class CLASS(sparksOmniSparklings): CLASS(sparksBurst1) {
@@ -191,6 +190,5 @@ class CfgCloudlets {
         lifeTimeVar = 1;
         moveVelocity[] = {-0.1, -1, 0.1};
         moveVelocityVar[] = {0.2, 2, 0.2};
-        postEffects = QCLASS(sparksSparkleEffect);
     };
 };

--- a/addons/effects/CfgCloudlets.hpp
+++ b/addons/effects/CfgCloudlets.hpp
@@ -1,10 +1,12 @@
 class CfgCloudlets {
     class Default;
+    // Blastwave Effects
     class CLASS(blastwave_effect_small): Default {
         angleVar = 1;
         animationName = "";
         animationSpeed[] = {1};
         beforeDestroyScript = "";
+        blockAIVisibility = 0;
         circleRadius = 0;
         circleVelocity[] = {0, 0, 0};
         colorVar[] = {0, 0, 0, 0};
@@ -51,5 +53,144 @@ class CfgCloudlets {
     class CLASS(blastwave_effect_very_large): CLASS(blastwave_effect_small) {
         lifeTime = 1;
         size[] = {1, 35, 80, 140, 200, 280};
+    };
+
+    // Spark Effects
+    class CLASS(sparksBurstLow): Default {
+        angleVar = 360;
+        animationName = "";
+        animationSpeed[] = {1000};
+        animationSpeedCoef = 1;
+        beforeDestroyScript = "";
+        blockAIVisibility = 0;
+        bounceOnSurface = 0.1;
+        bounceOnSurfaceVar = 0.2;
+        circleRadius = 0;
+        circleVelocity[] = {0, 0, 0};
+        color[] = {{1, 0.8, 0.8, -500}, {1, 0.3, 0.1, -500}};
+        colorCoef[] = {1, 1, 1, 1};
+        colorVar[] = {0.05, 0.05, 0.05, 5};
+        emissiveColor[] = {{250, 180, 10, 0}, {0, 0, 0, 0}};
+        interval = 0.001;
+        lifeTime = 0.015;
+        lifeTimeVar = 0.5;
+        moveVelocity[] = {"surfNormalX * inSpeed / 250 * 1.33","surfNormalY * inSpeed / 250 * 1.33","surfNormalZ * inSpeed / 250"};
+        moveVelocityVar[] = {1, 1, 1};
+        onTimerScript = "";
+        particleFSFrameCount = 2;
+        particleFSIndex = 13;
+        particleFSLoop = 0;
+        particleFSNtieth = 16;
+        particleShape = "\A3\data_f\ParticleEffects\Universal\Universal";
+        particleType = "Billboard";
+        position[] = {0, 0, 0};
+        positionVar[] = {0.01, 0.01, 0.01};
+        randomDirectionIntensity = 0;
+        randomDirectionIntensityVar = 2.3;
+        randomDirectionPeriod = 0;
+        randomDirectionPeriodVar = 0.09;
+        rotationVelocity = 1;
+        rotationVelocityVar = 0;
+        rubbing = 0.15;
+        size[] = {0.1, 0.035, 0};
+        sizeVar = 0.4;
+        timerPeriod = 3;
+        volume = 0.01;
+        weight = 1000;
+    };
+    class CLASS(sparksBurstMed): CLASS(sparksBurstLow) {
+        color[] = {{1, 0.3, 0.1, -500}, {1, 0.3, 0.1, -500}};
+        emissiveColor[] = {{235, 235, 250, 0}, {0, 0, 0, 0}};
+    };
+    class CLASS(sparksBurst): CLASS(sparksBurstLow) {
+        bounceOnSurface = 0.05;
+        bounceOnSurfaceVar = 0.1;
+        color[] = {{1, 0.3, 0.1, -500}, {1, 0.3, 0.1, -500}};
+        emissiveColor[] = {{250, 80, 25, 0}, {0, 0, 0, 0}};
+        lifeTimeVar = 1;
+        moveVelocity[] = {"surfNormalX * inSpeed / 250 * 0.66","surfNormalY * inSpeed / 250 * 0.66","surfNormalZ * inSpeed / 250 * 0.66"};
+        moveVelocityVar[] = {0.1, 0.1, 0.1};
+        randomDirectionIntensityVar = 0.2;
+        randomDirectionPeriodVar = 0.1;
+        size[] = {0.075, 0.015, 0};
+        sizeVar = 0.5;
+    };
+    class CLASS(sparksBurst1): CLASS(sparksBurstLow) {
+        animationSpeed[] = { 1000};
+        bounceOnSurface = 0.2;
+        bounceOnSurfaceVar = 0.3;
+        color[] = {{1, 0.3, 0.1, -500}, {1, 0.3, 0.1, -500}};
+        emissiveColor[] = {{250, 225, 160, 0}, {0, 0, 0, 0}};
+        lifeTimeVar = 1;
+        moveVelocity[] = {"surfNormalX * inSpeed / 250 * 0.66","surfNormalY * inSpeed / 250 * 0.66","surfNormalZ * inSpeed / 250 * 0.66"};
+        moveVelocityVar[] = {0.1, 0.1, 0.1};
+        randomDirectionIntensity = 0.1;
+        randomDirectionIntensityVar = 0.2;
+        randomDirectionPeriod = 0.05;
+        randomDirectionPeriodVar = 0.1;
+        size[] = {0.075, 0.015, 0};
+        sizeVar = 0.5;
+    };
+    class CLASS(sparksBurst2): CLASS(sparksBurstLow) {
+        bounceOnSurface = 0.2;
+        bounceOnSurfaceVar = 0.1;
+        color[] = {{1, 1, 0.9, -500}, {1, 0.3, 0.1, -500}};
+        emissiveColor[] = {{252, 255, 128, 0}, {0, 0, 0, 0}};
+        lifeTimeVar = 1;
+        moveVelocity[] = {"surfNormalX * inSpeed / 250","surfNormalY * inSpeed / 250","surfNormalZ * inSpeed / 250"};
+        moveVelocityVar[] = {"surfNormalX * inSpeed / 250","surfNormalY * inSpeed / 250","surfNormalZ * inSpeed / 250"};
+        randomDirectionIntensity = 1;
+        randomDirectionIntensityVar = 2;
+        randomDirectionPeriod = 0.5;
+        randomDirectionPeriodVar = 0.5;
+        rotationVelocityVar = 1;
+        size[] = {0.175, 0.015, 0};
+        sizeVar = 0.5;
+    };
+    class CLASS(sparkStream): CLASS(sparksBurst) {
+        bounceOnSurface = 0.1;
+        lifeTime = 0.15;
+        lifeTimeVar = 5;
+        moveVelocity[] = {1, 5, 1};
+    };
+    class CLASS(sparksOmni): CLASS(sparksBurst2) {
+        bounceOnSurface = 0.1;
+        interval = 0.008;
+        lifeTime = 0.05;
+        moveVelocity[] = {"surfNormalX * inSpeed / 200","surfNormalY * inSpeed / 200","surfNormalZ * inSpeed / 200"};
+        moveVelocityVar[] = {"surfNormalX * inSpeed / 200","surfNormalY * inSpeed / 200","surfNormalZ * inSpeed / 200"};
+    };
+    class CLASS(sparksOmniSparkle): CLASS(sparksOmni) {
+        interval = 0.5;
+        moveVelocity[] = {1, 1, 1};
+        moveVelocityVar[] = {0.1, -1, 0.1};
+        postEffects = QCLASS(sparksSparkleEffect);
+        size[] = {0.15, 0.05, 0};
+    };
+    class CLASS(sparksOmniSparklings): CLASS(sparksBurst1) {
+        interval = 0.0003;
+        lifeTime = 0.003;
+        lifeTimeVar = 1;
+        moveVelocity[] = {0.7, 0.7, 0.1};
+        moveVelocityVar[] = {2, 2, 0.3};
+    };
+    class CLASS(sparksDrop): CLASS(sparksBurst) {
+        bounceOnSurface = 0.1;
+        bounceOnSurfaceVar = 0.2;
+        interval = 0.02;
+        lifeTime = 0.05;
+        lifeTimeVar = 3;
+        moveVelocity[] = {0.3, -2, 0.3};
+        moveVelocityVar[] = {0.3, 0, 0.3};
+    };
+    class CLASS(sparksDrop2): CLASS(sparksBurst) {
+        bounceOnSurface = 0;
+        bounceOnSurfaceVar = 0;
+        interval = 100;
+        lifeTime = 0.5;
+        lifeTimeVar = 1;
+        moveVelocity[] = {-0.1, -1, 0.1};
+        moveVelocityVar[] = {0.2, 2, 0.2};
+        postEffects = QCLASS(sparksSparkleEffect);
     };
 };

--- a/addons/effects/blastwaveEffects.hpp
+++ b/addons/effects/blastwaveEffects.hpp
@@ -1,10 +1,12 @@
 #define MACRO_FX \
-    position[] = {0, 0, 0}; \
     intensity = 1; \
     interval = 3; \
     lifeTime = 1; \
+    position[] = {0, 0, 0}; \
+    qualityLevel = -1; \
     simulation = "particles"
 
+// Adds a refraction effect to explosions, these play everytime for everybody.
 class 120mm_HE {
     class CLASS(blastwave_refract) {
         type = QCLASS(blastwave_effect_medium);

--- a/addons/effects/config.cpp
+++ b/addons/effects/config.cpp
@@ -16,4 +16,5 @@ class CfgPatches {
 
 #include "CfgAmmo.hpp"
 #include "CfgCloudlets.hpp"
-#include "Effects.hpp"
+#include "blastwaveEffects.hpp"
+#include "impactEffects.hpp"

--- a/addons/effects/impactEffects.hpp
+++ b/addons/effects/impactEffects.hpp
@@ -51,15 +51,6 @@ class ImpactMetal {
         lifeTime = 1;
         qualityLevel = 2;
     };
-    class CLASS(sparksSparkleEffect) {
-        simulation = "particles";
-        type = QCLASS(starterSparksOmniSparklings);
-        position[] = {0, 0, 0};
-        intensity = 1;
-        interval = 1;
-        lifeTime = 0.03;
-        qualityLevel = 2;
-    };
 };
 
 // Increases the visual effect of hitting something slightly, follow the same particle settings as vanilla does.

--- a/addons/effects/impactEffects.hpp
+++ b/addons/effects/impactEffects.hpp
@@ -1,0 +1,222 @@
+// Spark Effects from Metal, these only play on particles high settings.
+class ImpactMetal {
+    class CLASS(startSparksBurstLow) {
+        simulation = "particles";
+        type = QCLASS(sparksBurstLow);
+        position[] = {0,0,0};
+        intensity = 1;
+        interval = 0.1;
+        lifeTime = 0.4;
+        randomDirectionPeriodVar = 1;
+        randomDirectionIntensityVar = 1;
+        qualityLevel = 2;
+    };
+    class CLASS(startSparksBurstMed) {
+        simulation = "particles";
+        type = QCLASS(sparksBurstMed);
+        position[] = {0,0,0};
+        intensity = 1;
+        interval = 0.1;
+        lifeTime = 0.6;
+        randomDirectionPeriodVar = 1;
+        randomDirectionIntensityVar = 1;
+        qualityLevel = 2;
+    };
+    class CLASS(startSparksOmni) {
+        simulation = "particles";
+        type = QCLASS(sparksOmni);
+        position[] = {0,0,0};
+        intensity = 1;
+        interval = 10;
+        randomDirectionPeriodVar = 0.5;
+        randomDirectionIntensityVar = 2;
+        lifeTime = 1;
+        qualityLevel = 2;
+    };
+    class CLASS(startSparksDrop) {
+        simulation = "particles";
+        type = QCLASS(sparksDrop);
+        position[] = {0,0,0};
+        intensity = 1;
+        interval = 11;
+        lifeTime = 1.5;
+        qualityLevel = 2;
+    };
+    class CLASS(startSparksDrop2) {
+        simulation = "particles";
+        type = QCLASS(sparksDrop2);
+        position[] = {0,0,0};
+        intensity = 1;
+        interval = 1;
+        lifeTime = 1;
+        qualityLevel = 2;
+    };
+    class CLASS(sparksSparkleEffect) {
+        simulation = "particles";
+        type = QCLASS(starterSparksOmniSparklings);
+        position[] = {0, 0, 0};
+        intensity = 1;
+        interval = 1;
+        lifeTime = 0.03;
+        qualityLevel = 2;
+    };
+};
+
+// Increases the visual effect of hitting something slightly, follow the same particle settings as vanilla does.
+class ImpactConcrete {
+    class ImpactDust {
+        intensity = 2;
+        interval = 1;
+        lifeTime = 3;
+        position[] = {0, 0, 0};
+        simulation = "particles";
+        type = "ImpactDustConcrete";
+    };
+    class ImpactDust2 {
+        intensity = 2;
+        interval = 1;
+        lifeTime = 3;
+        position[] = {0, 0, 0};
+        simulation = "particles";
+        type = "ImpactDustConcrete2";
+    };
+};
+
+class ImpactEffectsSmall {
+    class ImpactDust1 {
+        intensity = 2;
+        interval = 1;
+        lifeTime = 3;
+        position[] = {0, 0, 0};
+        qualityLevel = 2;
+        simulation = "particles";
+        type = "ImpactDust2";
+    };
+    class ImpactDust1Med {
+        intensity = 2;
+        interval = 1;
+        lifeTime = 3;
+        position[] = {0, 0, 0};
+        qualityLevel = 1;
+        simulation = "particles";
+        type = "ImpactDust2";
+    };
+    class ImpactDust1Low {
+        intensity = 2;
+        interval = 1;
+        lifeTime = 3;
+        position[] = {0, 0, 0};
+        qualityLevel = 0;
+        simulation = "particles";
+        type = "ImpactDust2Low";
+    };
+    class ImpactDustWater1 {
+        intensity = 2;
+        interval = 1;
+        lifeTime = 3;
+        position[] = {0, 0, 0};
+        simulation = "particles";
+        type = "ImpactDustWater2";
+    };
+    class ImpactConcrete {
+        intensity = 2;
+        interval = 1;
+        lifeTime = 3;
+        position[] = {0, 0, 0};
+        qualityLevel = 2;
+        simulation = "particles";
+        type = "ImpactConcrete";
+    };
+    class ImpactConcreteMed {
+        intensity = 2;
+        interval = 1;
+        lifeTime = 3;
+        position[] = {0, 0, 0};
+        qualityLevel = 1;
+        simulation = "particles";
+        type = "ImpactConcrete";
+    };
+    class ImpactEffectsSmall06 {
+        intensity = 2;
+        interval = 1;
+        lifeTime = 3;
+        position[] = {0, 0, 0};
+        simulation = "particles";
+        type = "ImpactSandSmoke2";
+    };
+};
+
+class ImpactPlaster {
+    class ImpactDust1 {
+        intensity = 2;
+        interval = 1;
+        lifeTime = 3;
+        position[] = {0, 0, 0};
+        qualityLevel = 2;
+        simulation = "particles";
+        type = "ImpactDustPlaster";
+    };
+    class ImpactDust1Med {
+        intensity = 2;
+        interval = 1;
+        lifeTime = 3;
+        position[] = {0, 0, 0};
+        qualityLevel = 1;
+        simulation = "particles";
+        type = "ImpactDustPlaster";
+    };
+    class ImpactDust1Low {
+        intensity = 2;
+        interval = 1;
+        lifeTime = 3;
+        position[] = {0, 0, 0};
+        qualityLevel = 0;
+        simulation = "particles";
+        type = "ImpactDustPlasterLow";
+    };
+    class ImpactConcreteWall01 {
+        intensity = 2;
+        interval = 1;
+        lifeTime = 3;
+        position[] = {0, 0, 0};
+        qualityLevel = 2;
+        simulation = "particles";
+        type = "ImpactConcreteWall1";
+    };
+    class ImpactConcreteWall02 {
+        intensity = 2;
+        interval = 1;
+        lifeTime = 3;
+        position[] = {0, 0, 0};
+        qualityLevel = 2;
+        simulation = "particles";
+        type = "ImpactConcreteWall2";
+    };
+    class ImpactConcreteWall02Med {
+        intensity = 2;
+        interval = 1;
+        lifeTime = 3;
+        position[] = {0, 0, 0};
+        qualityLevel = 1;
+        simulation = "particles";
+        type = "ImpactConcreteWall2";
+    };
+    class ImpactConcreteWall03 {
+        intensity = 2;
+        interval = 1;
+        lifeTime = 3;
+        position[] = {0, 0, 0};
+        qualityLevel = 2;
+        simulation = "particles";
+        type = "ImpactConcreteWall3";
+    };
+    class ImpactConcreteWall03Med {
+        intensity = 2;
+        interval = 1;
+        lifeTime = 3;
+        position[] = {0, 0, 0};
+        qualityLevel = 1;
+        simulation = "particles";
+        type = "ImpactConcreteWall3";
+    };
+};


### PR DESCRIPTION
**Blastwave Stuff**
- Forces the refraction effect to show on every player regardless of video settings.
- Disable blocking AI visibility on refraction effect (supposedly better performance)

**Impact Effects**
- Increase the bullet hit effect on the ground and other objects slightly, makes it more visible (ground & walls)
- Adds a sparking effect for hitting metal, only in effect on high particle settings for performance reasons.

